### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -10,7 +10,7 @@ pkgbase = mkinitcpio-tailscale
 	source = initcpio-install-tailscale
 	source = setup-initcpio-tailscale
 	sha256sums = ce5df937e08ee7791921aad719413640aca445083694b2f526008a8ad53d4155
-	sha256sums = 0fc9d871b19341f90d49772f1c44383030fe969a8507f3dcffaf3acc86f3a42c
+	sha256sums = 68d6a305f950f944e858f02032347ea9d3139a873effb67242fdcb2c06cae7ea
 	sha256sums = 745a12f097fcfe4a3b6b5a76e6b43fefa84efc93628131b8c87a8a40cd45545f
 
 pkgname = mkinitcpio-tailscale

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = mkinitcpio-tailscale
 	pkgdesc = mkinitcpio hook to launch Tailscale on systemd or busybox based initramfs
-	pkgver = 1.1.0
+	pkgver = 1.2.0
 	pkgrel = 1
 	url = https://github.com/dangra/mkinitcpio-tailscale
 	arch = any

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,131 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    timeout-minutes: 10
+    steps:
+      # git has to be installed before actions/checkout, otherwise it falls back
+      # to downloading a REST tarball.
+      - name: Bootstrap
+        run: pacman -Syu --noconfirm --needed git shellcheck mkinitcpio
+
+      - uses: actions/checkout@v4
+
+      # Findings from shellcheck are reported but do not fail the build; syntax
+      # errors do. See tests/01-lint.sh.
+      - name: Static checks
+        run: ./tests/01-lint.sh
+
+  package:
+    name: package
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    timeout-minutes: 20
+    steps:
+      - name: Bootstrap
+        run: |
+          pacman -Syu --noconfirm --needed git pacman-contrib namcap mkinitcpio
+          # makepkg refuses to run as root, and that guard also covers
+          # --printsrcinfo and the `makepkg -g` that updpkgsums shells out to.
+          useradd -m builder
+
+      - uses: actions/checkout@v4
+
+      - name: Prepare workspace
+        run: |
+          git config --system --add safe.directory "$GITHUB_WORKSPACE"
+          install -d -o builder -g builder "$GITHUB_WORKSPACE/dist"
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+
+      - name: Metadata, makepkg, namcap and payload checks
+        run: runuser -u builder -- ./tests/02-package.sh
+        env:
+          ARTIFACT_DIR: ${{ github.workspace }}/dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: package
+          path: dist/*.pkg.tar.zst
+          if-no-files-found: error
+          retention-days: 7
+
+  initramfs:
+    name: initramfs
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    timeout-minutes: 30
+    steps:
+      - name: Bootstrap
+        run: |
+          # Installing a kernel triggers mkinitcpio -P against the stock preset,
+          # which cannot work in a container (autodetect needs the real host).
+          # Disabling only this hook keeps 60-depmod.hook, which the tests need
+          # for modules.dep.
+          install -d /etc/pacman.d/hooks
+          ln -sf /dev/null /etc/pacman.d/hooks/90-mkinitcpio-install.hook
+          # mkinitcpio is named explicitly because linux depends on the virtual
+          # "initramfs" provider and --noconfirm could otherwise pick dracut.
+          # iptables is explicit too: the tailscale package does not depend on
+          # it, but the hook calls add_binary iptables.
+          pacman -Syu --noconfirm --needed \
+            git mkinitcpio linux tailscale iptables openssh
+
+      - uses: actions/checkout@v4
+
+      # Builds real images for the systemd, busybox and Tailscale-SSH variants
+      # and asserts on their contents. Uses the hook files from the working tree
+      # -- the package job separately proves the package ships exactly those
+      # files at the paths mkinitcpio looks in.
+      - name: Build and inspect initramfs images
+        run: ./tests/03-initramfs.sh
+        env:
+          ARTIFACT_DIR: ${{ github.workspace }}/logs
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: initramfs-logs
+          path: logs/
+          if-no-files-found: ignore
+
+  boot:
+    name: boot
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      # Deliberately not a `container:` job. tests/container.sh only passes
+      # --device /dev/kvm when the device exists, so a runner without KVM falls
+      # back to TCG instead of failing at container creation. It also keeps this
+      # identical to how the test runs locally.
+      - name: Boot the initramfs under QEMU against a throwaway headscale
+        run: ./tests/container.sh 04
+        env:
+          # Runners ship both engines; docker runs rootful here, which is what
+          # makes --device /dev/kvm usable.
+          ENGINE: docker
+          ARTIFACT_DIR: ${{ github.workspace }}/logs
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: boot-logs
+          path: logs/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Bootstrap
         run: pacman -Syu --noconfirm --needed git shellcheck mkinitcpio
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Findings from shellcheck are reported but do not fail the build; syntax
       # errors do. See tests/01-lint.sh.
@@ -45,7 +45,7 @@ jobs:
           # --printsrcinfo and the `makepkg -g` that updpkgsums shells out to.
           useradd -m builder
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Prepare workspace
         run: |
@@ -58,7 +58,7 @@ jobs:
         env:
           ARTIFACT_DIR: ${{ github.workspace }}/dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: package
           path: dist/*.pkg.tar.zst
@@ -86,7 +86,7 @@ jobs:
           pacman -Syu --noconfirm --needed \
             git mkinitcpio linux tailscale iptables openssh
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Builds real images for the systemd, busybox and Tailscale-SSH variants
       # and asserts on their contents. Uses the hook files from the working tree
@@ -97,7 +97,7 @@ jobs:
         env:
           ARTIFACT_DIR: ${{ github.workspace }}/logs
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: initramfs-logs
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Deliberately not a `container:` job. tests/container.sh only passes
       # --device /dev/kvm when the device exists, so a runner without KVM falls
@@ -123,7 +123,7 @@ jobs:
           ENGINE: docker
           ARTIFACT_DIR: ${{ github.workspace }}/logs
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: always()
         with:
           name: boot-logs

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: build install update checksums srcinfo
+.PHONY: build install update checksums srcinfo publish test test-all
 
 
 build: update
@@ -18,3 +18,11 @@ srcinfo:
 
 publish:
 	git push ssh://aur@aur.archlinux.org/mkinitcpio-tailscale.git
+
+# Runs the same scripts CI does, in a throwaway Arch container.
+test:
+	./tests/container.sh
+
+# Adds the QEMU boot test against a throwaway headscale server.
+test-all:
+	./tests/container.sh all

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer:  Daniel Graña <dangra at gmail dot com>
 
 pkgname=mkinitcpio-tailscale
-pkgver=1.1.0
+pkgver=1.2.0
 pkgrel=1
 pkgdesc="mkinitcpio hook to launch Tailscale on systemd or busybox based initramfs"
 arch=("any")

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,7 @@ source=("initcpio-hooks-tailscale"
   "initcpio-install-tailscale"
   "setup-initcpio-tailscale")
 sha256sums=('ce5df937e08ee7791921aad719413640aca445083694b2f526008a8ad53d4155'
-            '0fc9d871b19341f90d49772f1c44383030fe969a8507f3dcffaf3acc86f3a42c'
+            '68d6a305f950f944e858f02032347ea9d3139a873effb67242fdcb2c06cae7ea'
             '745a12f097fcfe4a3b6b5a76e6b43fefa84efc93628131b8c87a8a40cd45545f')
 
 package() {

--- a/initcpio-install-tailscale
+++ b/initcpio-install-tailscale
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 
 build() {
+	# mkinitcpio's run_build_hook discards build()'s return value, so returning
+	# 1 on its own reports the problem and still lets the image be generated.
+	# Bumping _builderrors is how a hook actually aborts the build; mkinitcpio
+	# declares and consumes it, and its own acpi_override hook does the same.
+	# shellcheck disable=SC2034
 	if ! pacman -Qi tailscale >/dev/null 2>&1; then
 		error "Package tailscale not installed"
+		builderrors=$((++_builderrors))
 		return 1
 	fi
 
@@ -10,6 +16,8 @@ build() {
 	for fn in tailscaled.state default.env; do
 		if ! [[ -r "${setupdir}/${fn}" && -s "${setupdir}/${fn}" ]]; then
 			error "Missing configuration file at ${setupdir}/${fn}. Have you run setup-initcpio-tailscale yet?"
+			# shellcheck disable=SC2034
+			builderrors=$((++_builderrors))
 			return 1
 		fi
 	done

--- a/tests/01-lint.sh
+++ b/tests/01-lint.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Static checks.
+#
+# Findings from shellcheck are advisory: they are printed (and surfaced in the
+# job summary on CI) but never fail the run. Syntax errors are different --
+# a script that does not parse is unambiguously broken, so `bash -n` and the
+# busybox `ash -n` check are blocking.
+set -uo pipefail
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+
+cd "$REPO_ROOT" || die "cannot cd to $REPO_ROOT"
+
+SCRIPTS=(initcpio-install-tailscale initcpio-hooks-tailscale setup-initcpio-tailscale)
+TEST_SCRIPTS=(tests/*.sh)
+
+group 'shellcheck (advisory)'
+if command -v shellcheck >/dev/null 2>&1; then
+	sc_out=$(shellcheck "${SCRIPTS[@]}" "${TEST_SCRIPTS[@]}" 2>&1) || true
+	# SC2034/SC2154 are structural in a PKGBUILD (makepkg assigns and consumes
+	# these), so they are excluded rather than reported as noise every run.
+	pkgbuild_out=$(shellcheck --shell=bash --exclude=SC2034,SC2154 PKGBUILD 2>&1) || true
+
+	if [[ -n $sc_out || -n $pkgbuild_out ]]; then
+		printf '%s\n' "$sc_out" "$pkgbuild_out"
+		if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+			{
+				printf '### shellcheck (advisory)\n\n```\n'
+				printf '%s\n' "$sc_out" "$pkgbuild_out"
+				printf '```\n'
+			} >>"$GITHUB_STEP_SUMMARY"
+		fi
+		warn 'shellcheck reported findings (not failing the build)'
+	else
+		info 'shellcheck is clean'
+	fi
+else
+	warn 'shellcheck not installed; skipping'
+fi
+endgroup
+
+group 'bash syntax'
+for f in "${SCRIPTS[@]}" PKGBUILD "${TEST_SCRIPTS[@]}"; do
+	check "$f parses as bash" bash -n "$f"
+done
+endgroup
+
+group 'busybox ash syntax'
+# /usr/lib/initcpio/init runs under busybox ash, so the runtime hook it sources
+# has to parse there. Arch builds busybox with bash compatibility, which is why
+# the [[ ]] in run_cleanuphook is fine today -- this check is what keeps that
+# assumption honest if the busybox build options ever change.
+if bb=$(initcpio_busybox); then
+	check 'initcpio-hooks-tailscale parses as busybox ash' \
+		"$bb" ash -n initcpio-hooks-tailscale
+else
+	warn 'busybox not found; skipping ash syntax check'
+fi
+endgroup
+
+group 'hook contracts'
+# mkinitcpio sources these files and calls the functions by name; a rename would
+# leave a hook that builds cleanly and then does nothing at boot.
+check 'install hook defines build()' grep -Eq '^build\(\)' initcpio-install-tailscale
+check 'install hook defines help()' grep -Eq '^help\(\)' initcpio-install-tailscale
+check 'runtime hook defines run_hook()' grep -Eq '^run_hook\(\)' initcpio-hooks-tailscale
+check 'runtime hook defines run_cleanuphook()' grep -Eq '^run_cleanuphook\(\)' initcpio-hooks-tailscale
+endgroup
+
+summary

--- a/tests/02-package.sh
+++ b/tests/02-package.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Packaging checks: metadata drift, a real makepkg build, namcap, and payload
+# assertions on the resulting package.
+#
+# Everything happens in a temporary copy of the sources, so this never dirties
+# the working tree -- which also means the drift checks work without git.
+#
+# makepkg refuses to run as root, and that guard covers --printsrcinfo and the
+# `makepkg -g` that updpkgsums shells out to, so this whole script must run
+# unprivileged.
+set -uo pipefail
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+
+[[ $(id -u) != 0 ]] || die 'makepkg refuses to run as root; run this script as an unprivileged user'
+need_cmd makepkg updpkgsums namcap bsdtar
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Only the files makepkg needs. Copying rather than working in place keeps
+# updpkgsums from rewriting the developer's PKGBUILD.
+cp -t "$WORK" \
+	"$REPO_ROOT/PKGBUILD" \
+	"$REPO_ROOT/initcpio-hooks-tailscale" \
+	"$REPO_ROOT/initcpio-install-tailscale" \
+	"$REPO_ROOT/setup-initcpio-tailscale" || die 'failed to stage sources'
+cd "$WORK" || die "cannot cd to $WORK"
+
+group 'metadata is in sync with the sources'
+
+# The failure people actually hit: edit a source script, forget `make update`,
+# push a PKGBUILD whose sha256sums no longer match. makepkg would reject it at
+# build time anyway, but this check names the fix.
+if updpkgsums >"$WORK/updpkgsums.log" 2>&1; then
+	if diff -u "$REPO_ROOT/PKGBUILD" "$WORK/PKGBUILD" >"$WORK/pkgbuild.diff"; then
+		pass 'PKGBUILD sha256sums match the sources'
+	else
+		fail 'PKGBUILD sha256sums match the sources' \
+			"$(printf 'run "make checksums" (or "make update") and commit the result\n\n%s' "$(cat "$WORK/pkgbuild.diff")")"
+	fi
+else
+	fail 'updpkgsums runs' "$(cat "$WORK/updpkgsums.log")"
+fi
+
+if makepkg --printsrcinfo >"$WORK/SRCINFO.new" 2>"$WORK/srcinfo.err"; then
+	if diff -u "$REPO_ROOT/.SRCINFO" "$WORK/SRCINFO.new" >"$WORK/srcinfo.diff"; then
+		pass '.SRCINFO matches the PKGBUILD'
+	else
+		fail '.SRCINFO matches the PKGBUILD' \
+			"$(printf 'run "make srcinfo" (or "make update") and commit the result\n\n%s' "$(cat "$WORK/srcinfo.diff")")"
+	fi
+else
+	fail 'makepkg --printsrcinfo runs' "$(cat "$WORK/srcinfo.err")"
+fi
+endgroup
+
+group 'namcap PKGBUILD'
+# namcap exits 0 even when it reports errors, so grade its output instead.
+namcap PKGBUILD 2>&1 | tee "$WORK/namcap-pkgbuild.log"
+check_fails 'namcap reports no errors for PKGBUILD' grep -q ' E: ' "$WORK/namcap-pkgbuild.log"
+endgroup
+
+group 'makepkg build'
+# --nodeps: the sole dependency is mkinitcpio and building this package does not
+# need it installed, which keeps this job free of sudo/pacman.
+if makepkg --noconfirm --nodeps --force --cleanbuild >"$WORK/makepkg.log" 2>&1; then
+	pass 'makepkg builds the package'
+else
+	fail 'makepkg builds the package' "$(tail -40 "$WORK/makepkg.log")"
+	summary
+	exit 1
+fi
+endgroup
+
+PKG=$(echo "$WORK"/mkinitcpio-tailscale-*.pkg.tar.zst)
+[[ -f $PKG ]] || die 'makepkg reported success but produced no package'
+info "built $(basename "$PKG")"
+
+group 'namcap package'
+namcap "$PKG" 2>&1 | tee "$WORK/namcap-pkg.log"
+check_fails 'namcap reports no errors for the package' grep -q ' E: ' "$WORK/namcap-pkg.log"
+endgroup
+
+group 'package payload'
+bsdtar -tvf "$PKG" | awk '{print $1, $NF}' >"$WORK/payload.modes"
+bsdtar -tf "$PKG" | grep -v '^\.' | grep -v '/$' | sort >"$WORK/payload.files"
+
+# Modes matter: setup-initcpio-tailscale is run directly by the user, while the
+# two initcpio files are sourced by mkinitcpio and must not be executable.
+while read -r mode path; do
+	if grep -qxF -- "$mode $path" "$WORK/payload.modes"; then
+		pass "package ships $path as $mode"
+	else
+		fail "package ships $path as $mode" \
+			"$(printf 'actual entries:\n%s' "$(grep -F -- "$path" "$WORK/payload.modes" || echo '  (path absent)')")"
+	fi
+done <<-'EOF'
+	-rw-r--r-- usr/lib/initcpio/hooks/tailscale
+	-rw-r--r-- usr/lib/initcpio/install/tailscale
+	-rwxr-xr-x usr/bin/setup-initcpio-tailscale
+EOF
+
+# Guards against a stray file sneaking into the package.
+if diff -u - "$WORK/payload.files" >"$WORK/payload.diff" <<-'EOF'; then
+	usr/bin/setup-initcpio-tailscale
+	usr/lib/initcpio/hooks/tailscale
+	usr/lib/initcpio/install/tailscale
+EOF
+	pass 'package contains exactly the expected files'
+else
+	fail 'package contains exactly the expected files' "$(cat "$WORK/payload.diff")"
+fi
+
+# The packaged files must be the working-tree files, not a stale copy.
+bsdtar -xOf "$PKG" usr/lib/initcpio/install/tailscale >"$WORK/installed-hook"
+check 'packaged install hook matches the source file' \
+	cmp -s "$WORK/installed-hook" "$REPO_ROOT/initcpio-install-tailscale"
+endgroup
+
+# Hand the package to the caller (CI uploads it as an artifact and the boot test
+# installs it).
+if [[ -n ${ARTIFACT_DIR:-} ]]; then
+	install -d "$ARTIFACT_DIR"
+	cp "$PKG" "$ARTIFACT_DIR/"
+	info "copied $(basename "$PKG") to $ARTIFACT_DIR"
+fi
+
+summary

--- a/tests/03-initramfs.sh
+++ b/tests/03-initramfs.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Build real initramfs images with the hook and assert on their contents.
+#
+# By default the hook files are taken straight from the working tree via
+# mkinitcpio's -D flag, so this needs nothing installed and is fast to iterate
+# on. Pass --installed to test /usr/lib/initcpio/{install,hooks}/tailscale as
+# laid down by the built package instead.
+set -uo pipefail
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+. "$(dirname -- "${BASH_SOURCE[0]}")/fixtures.sh"
+
+USE_INSTALLED=0
+[[ ${1:-} == --installed ]] && USE_INSTALLED=1
+
+need_root
+need_cmd mkinitcpio lsinitcpio depmod ssh-keygen
+
+# The install hook bails out unless the tailscale package is present, and
+# add_binary/add_full_dir need the iptables userland -- which tailscale does not
+# depend on, so it has to be installed in its own right.
+need_pkg tailscale iptables
+
+WORK=$(mktemp -d)
+BUILD_N=0
+
+# Simulating "tailscale is not installed" cannot be done with a PATH shim:
+# mkinitcpio hard-resets PATH to /usr/bin:/bin at startup (mkinitcpio:39), so
+# the hook's `pacman -Qi tailscale` always finds the real binary. Swapping
+# /usr/bin/pacman itself is the only thing that works, which is safe here
+# because fixtures_init already refuses to run outside a container.
+PACMAN_SHIMMED=0
+
+shim_pacman() {
+	mv /usr/bin/pacman /usr/bin/pacman.real || die 'could not move pacman aside'
+	cat >/usr/bin/pacman <<-'EOF'
+		#!/usr/bin/env bash
+		[[ $1 == -Qi && $2 == tailscale ]] && exit 1
+		exec /usr/bin/pacman.real "$@"
+	EOF
+	chmod 755 /usr/bin/pacman
+	PACMAN_SHIMMED=1
+}
+
+unshim_pacman() {
+	((PACMAN_SHIMMED)) || return 0
+	rm -f /usr/bin/pacman
+	mv /usr/bin/pacman.real /usr/bin/pacman
+	PACMAN_SHIMMED=0
+}
+
+# fixtures_init installs its own EXIT trap; chain ours so both run.
+cleanup_all() {
+	local rc=$?
+	unshim_pacman
+	rm -rf "$WORK"
+	fixtures_cleanup
+	return $rc
+}
+
+fixtures_init
+trap cleanup_all EXIT
+
+# --- kernel ---------------------------------------------------------------
+# The container's `uname -r` is the runner's kernel, for which no module tree
+# exists, so take the version from whichever tree a kernel package installed.
+KVER=''
+for d in /usr/lib/modules/*/; do
+	[[ -f ${d}pkgbase ]] && KVER=$(basename "$d")
+done
+[[ -n $KVER ]] || die 'no kernel module tree found; install the linux package'
+[[ -f /usr/lib/modules/$KVER/modules.dep ]] || depmod -a "$KVER" ||
+	die "depmod failed for $KVER"
+info "building against kernel $KVER"
+
+# --- where mkinitcpio looks for the hook ----------------------------------
+MKI_HOOKDIR_ARGS=()
+if ((USE_INSTALLED)); then
+	[[ -f /usr/lib/initcpio/install/tailscale ]] ||
+		die '--installed given but /usr/lib/initcpio/install/tailscale is missing'
+	info 'testing the installed hook'
+else
+	HOOKDIR="$WORK/hookdir"
+	install -d "$HOOKDIR/install" "$HOOKDIR/hooks"
+	install -m644 "$REPO_ROOT/initcpio-install-tailscale" "$HOOKDIR/install/tailscale"
+	install -m644 "$REPO_ROOT/initcpio-hooks-tailscale" "$HOOKDIR/hooks/tailscale"
+	# -D replaces the entire search path rather than prepending to it, so the
+	# stock directory has to be named explicitly or `base`/`systemd` disappear.
+	MKI_HOOKDIR_ARGS=(-D "$HOOKDIR" -D /usr/lib/initcpio)
+	info 'testing the hook files from the working tree'
+fi
+
+# --- helpers --------------------------------------------------------------
+
+# build_image <hooks> -> sets IMG, LOG, LIST, ROOT; returns mkinitcpio's status
+build_image() {
+	local hooks=$1 conf
+	BUILD_N=$((BUILD_N + 1))
+	conf="$WORK/mkinitcpio.$BUILD_N.conf"
+	IMG="$WORK/image.$BUILD_N.img"
+	LOG="$WORK/build.$BUILD_N.log"
+	ROOT="$WORK/root.$BUILD_N"
+
+	# COMPRESSION=cat keeps everything in a single cpio. Compressed images get
+	# their *.zst kernel modules moved into a separate early cpio, which
+	# duplicates directory entries and makes exact-match assertions ambiguous.
+	cat >"$conf" <<-EOF
+		MODULES=()
+		BINARIES=()
+		FILES=()
+		HOOKS=($hooks)
+		COMPRESSION="cat"
+	EOF
+
+	# -n disables colour so the negative tests can grep the log reliably.
+	mkinitcpio -n "${MKI_HOOKDIR_ARGS[@]}" -c "$conf" -k "$KVER" -g "$IMG" \
+		>"$LOG" 2>&1
+}
+
+# snapshot — list and extract the image just built
+snapshot() {
+	LIST="$WORK/list.$BUILD_N"
+	lsinitcpio -l "$IMG" >"$LIST" || die 'lsinitcpio -l failed'
+	install -d "$ROOT"
+	(cd "$ROOT" && lsinitcpio -x "$IMG" >/dev/null) || die 'lsinitcpio -x failed'
+}
+
+in_list() { grep -qxF -- "$1" "$LIST"; }
+
+# Shared expectations for every successful build.
+assert_common() {
+	local label=$1
+	check "$label: tailscaled binary" in_list usr/bin/tailscaled
+	check "$label: tailscale binary" in_list usr/bin/tailscale
+	check "$label: getent" in_list usr/bin/getent
+	check "$label: iptables" in_list usr/bin/iptables
+	check "$label: ip6tables" in_list usr/bin/ip6tables
+	img_has_glob "$ROOT" 'usr/lib/xtables/lib*.so' "$label: xtables plugins present"
+	img_has_glob "$ROOT" "usr/lib/modules/$KVER/kernel/drivers/net/tun.ko*" "$label: tun module present"
+
+	local nf
+	nf=$(grep -cE 'kernel/net/netfilter/.*\.ko' "$LIST")
+	if ((nf > 20)); then
+		pass "$label: netfilter modules present ($nf)"
+	else
+		fail "$label: netfilter modules present" "only $nf found, expected >20"
+	fi
+
+	# The configuration copied off the host must arrive intact at the paths the
+	# runtime hook and tailscaled read.
+	img_same "$ROOT" etc/default/tailscaled "$FIXTURE_SRC/default.env"
+	img_same "$ROOT" var/lib/tailscale/tailscaled.state "$FIXTURE_SRC/tailscaled.state"
+
+	# Both the runtime hook and Arch's tailscaled.service invoke
+	# /usr/sbin/tailscaled. mkinitcpio creates usr/sbin as a *relative* symlink
+	# to bin, so this resolves inside the extracted image rather than leaking
+	# out to the host.
+	img_symlink "$ROOT" usr/sbin bin
+	check "$label: /usr/sbin/tailscaled resolves in-image" test -x "$ROOT/usr/sbin/tailscaled"
+}
+
+# --- variant A: systemd ---------------------------------------------------
+group 'variant A: systemd initramfs'
+fixtures_write
+if build_image 'base systemd tailscale'; then
+	pass 'A: mkinitcpio builds'
+	snapshot
+	assert_common A
+
+	img_has "$ROOT" usr/lib/systemd/system/tailscaled.service
+	img_has "$ROOT" etc/systemd/system/tailscaled.service.d/override.conf
+	img_grep "$ROOT" etc/systemd/system/tailscaled.service.d/override.conf '^DefaultDependencies=no$'
+	img_grep "$ROOT" etc/systemd/system/tailscaled.service.d/override.conf '^After=network-online\.target$'
+	img_grep "$ROOT" etc/systemd/system/tailscaled.service.d/override.conf '^Wants=network-online\.target$'
+	# An absolute symlink target, so compare the link text -- following it would
+	# resolve against the host and pass even with the unit missing.
+	img_symlink "$ROOT" etc/systemd/system/sysinit.target.wants/tailscaled.service \
+		/usr/lib/systemd/system/tailscaled.service
+
+	img_lacks "$ROOT" hooks/tailscale
+	img_lacks "$ROOT" var/lib/tailscale/ssh
+else
+	fail 'A: mkinitcpio builds' "$(tail -30 "$LOG")"
+fi
+endgroup
+
+# --- variant B: busybox ---------------------------------------------------
+group 'variant B: busybox initramfs'
+fixtures_write
+if build_image 'base udev tailscale'; then
+	pass 'B: mkinitcpio builds'
+	snapshot
+	assert_common B
+
+	img_has "$ROOT" hooks/tailscale
+	check 'B: runscript is executable' test -x "$ROOT/hooks/tailscale"
+	img_grep "$ROOT" hooks/tailscale '^run_hook\(\)'
+	img_grep "$ROOT" hooks/tailscale '^run_cleanuphook\(\)'
+	# mkinitcpio records which hooks /init should call; a runscript that is
+	# present but unregistered would never run.
+	img_grep "$ROOT" config '^HOOKS=.*\btailscale\b'
+	img_grep "$ROOT" config '^CLEANUPHOOKS=.*\btailscale\b'
+	if bb=$(initcpio_busybox); then
+		check 'B: runscript parses under busybox ash' "$bb" ash -n "$ROOT/hooks/tailscale"
+	fi
+
+	img_lacks "$ROOT" usr/lib/systemd/system/tailscaled.service
+	img_lacks "$ROOT" etc/systemd/system/tailscaled.service.d/override.conf
+else
+	fail 'B: mkinitcpio builds' "$(tail -30 "$LOG")"
+fi
+endgroup
+
+# --- variant C: systemd with Tailscale SSH host keys ----------------------
+group 'variant C: systemd initramfs with ssh host keys'
+fixtures_write --ssh
+if build_image 'base systemd tailscale'; then
+	pass 'C: mkinitcpio builds'
+	snapshot
+	assert_common C
+
+	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key
+	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key.pub
+	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_rsa_key
+	img_same "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key \
+		"$FIXTURE_SRC/ssh/ssh_host_ed25519_key"
+	# add_file preserves mode, so a host key must not become world-readable on
+	# its way into the image.
+	if [[ -f $ROOT/var/lib/tailscale/ssh/ssh_host_ed25519_key ]]; then
+		check 'C: private host key stays mode 600' \
+			test "$(stat -c %a "$ROOT/var/lib/tailscale/ssh/ssh_host_ed25519_key")" = 600
+	fi
+else
+	fail 'C: mkinitcpio builds' "$(tail -30 "$LOG")"
+fi
+endgroup
+
+# --- variants D-F: the guard clauses --------------------------------------
+#
+# Note on what these assert. mkinitcpio's run_build_hook deliberately discards
+# build()'s return value ("Hooks can do their own error catching"), and only
+# failures inside add_* functions bump the internal _builderrors counter. So a
+# guard clause that calls error() and returns 1 prints a message but does NOT
+# stop image generation -- mkinitcpio still exits 0.
+#
+# These tests therefore assert the contract that actually holds today: the
+# guard reports the problem and, crucially, no half-configured image is
+# produced (no state file, no env file, no tailscale binaries). If the hook is
+# ever changed to abort the build for real -- the stock idiom is
+# `builderrors=$(( ++_builderrors ))` before `return 1`, as in the acpi_override
+# hook -- tighten `assert_guard` to require a non-zero exit.
+group 'variants D-F: guard clauses reject bad configuration'
+
+# assert_guard <label> <error regex> — build must be refused by the hook
+assert_guard() {
+	local label=$1 re=$2 rc=0
+	build_image 'base systemd tailscale' || rc=$?
+
+	check "$label: the hook reports the problem" grep -qE "$re" "$LOG"
+
+	if ((rc == 0)); then
+		# Expected today; recorded rather than asserted so the suite documents
+		# the gap instead of hiding it.
+		info "  note: mkinitcpio still exited 0 ($label); the hook only warns"
+		snapshot
+		img_lacks "$ROOT" etc/default/tailscaled
+		img_lacks "$ROOT" var/lib/tailscale/tailscaled.state
+		img_lacks "$ROOT" usr/bin/tailscaled
+	else
+		pass "$label: mkinitcpio exits non-zero"
+	fi
+}
+
+fixtures_write
+: >"$TS_SETUPDIR/tailscaled.state"
+assert_guard 'D: empty tailscaled.state' 'setup-initcpio-tailscale'
+
+fixtures_write
+rm -f "$TS_SETUPDIR/default.env"
+assert_guard 'E: missing default.env' 'default\.env'
+
+fixtures_write
+shim_pacman
+assert_guard 'F: tailscale package absent' 'tailscale not installed'
+unshim_pacman
+endgroup
+
+if ((TESTS_FAILED)) && [[ -n ${ARTIFACT_DIR:-} ]]; then
+	install -d "$ARTIFACT_DIR"
+	cp "$WORK"/build.*.log "$ARTIFACT_DIR/" 2>/dev/null || true
+	info "copied build logs to $ARTIFACT_DIR"
+fi
+
+summary

--- a/tests/03-initramfs.sh
+++ b/tests/03-initramfs.sh
@@ -236,37 +236,36 @@ endgroup
 
 # --- variants D-F: the guard clauses --------------------------------------
 #
-# Note on what these assert. mkinitcpio's run_build_hook deliberately discards
-# build()'s return value ("Hooks can do their own error catching"), and only
-# failures inside add_* functions bump the internal _builderrors counter. So a
-# guard clause that calls error() and returns 1 prints a message but does NOT
-# stop image generation -- mkinitcpio still exits 0.
-#
-# These tests therefore assert the contract that actually holds today: the
-# guard reports the problem and, crucially, no half-configured image is
-# produced (no state file, no env file, no tailscale binaries). If the hook is
-# ever changed to abort the build for real -- the stock idiom is
-# `builderrors=$(( ++_builderrors ))` before `return 1`, as in the acpi_override
-# hook -- tighten `assert_guard` to require a non-zero exit.
+# mkinitcpio's run_build_hook deliberately discards build()'s return value
+# ("Hooks can do their own error catching"), and only failures inside add_*
+# functions bump the internal _builderrors counter. A guard clause that just
+# calls error() and returns 1 therefore prints a message while mkinitcpio still
+# exits 0 and writes an image -- which is why the hook bumps _builderrors
+# itself. These tests are what hold that behaviour in place.
 group 'variants D-F: guard clauses reject bad configuration'
 
-# assert_guard <label> <error regex> — build must be refused by the hook
+# assert_guard <label> <error regex> — the build must be refused outright
 assert_guard() {
 	local label=$1 re=$2 rc=0
 	build_image 'base systemd tailscale' || rc=$?
 
 	check "$label: the hook reports the problem" grep -qE "$re" "$LOG"
 
-	if ((rc == 0)); then
-		# Expected today; recorded rather than asserted so the suite documents
-		# the gap instead of hiding it.
-		info "  note: mkinitcpio still exited 0 ($label); the hook only warns"
+	if ((rc != 0)); then
+		pass "$label: mkinitcpio exits non-zero"
+	else
+		fail "$label: mkinitcpio exits non-zero" \
+			'the hook reported the problem but the build was allowed to succeed'
+	fi
+
+	# Nothing half-configured should be left behind either way.
+	if [[ -f $IMG ]]; then
 		snapshot
 		img_lacks "$ROOT" etc/default/tailscaled
 		img_lacks "$ROOT" var/lib/tailscale/tailscaled.state
 		img_lacks "$ROOT" usr/bin/tailscaled
 	else
-		pass "$label: mkinitcpio exits non-zero"
+		pass "$label: no image was written"
 	fi
 }
 

--- a/tests/04-boot.sh
+++ b/tests/04-boot.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# End-to-end boot test.
+#
+# Stands up a throwaway headscale control server, runs the real
+# setup-initcpio-tailscale against it to produce a genuine node key, builds an
+# initramfs with the hook, boots it under QEMU, and then asserts from
+# headscale's side that the initrd node registered and came online.
+#
+# That chain is the only thing that proves what the package actually claims:
+# state copied into the image -> tailscaled started inside the initramfs ->
+# network up -> node reachable on the tailnet. It also gives
+# setup-initcpio-tailscale its only coverage, via the non-interactive
+# --authkey path.
+#
+# This is the most environment-sensitive script in the suite; every external
+# moving part is parameterised below.
+#
+#   --installed   test /usr/lib/initcpio/... and /usr/bin/setup-initcpio-tailscale
+#                 from the built package instead of the working tree
+set -uo pipefail
+. "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
+. "$(dirname -- "${BASH_SOURCE[0]}")/fixtures.sh"
+
+HEADSCALE_VERSION=${HEADSCALE_VERSION:-0.26.1}
+BOOT_TIMEOUT=${BOOT_TIMEOUT:-300}
+TS_NODE_NAME=${TS_NODE_NAME:-ci-initrd}
+
+USE_INSTALLED=0
+[[ ${1:-} == --installed ]] && USE_INSTALLED=1
+
+need_root
+need_cmd mkinitcpio qemu-system-x86_64 curl jq depmod ssh-keygen
+need_pkg tailscale iptables
+
+WORK=$(mktemp -d)
+QEMU_PID=''
+HEADSCALE_PID=''
+
+cleanup_all() {
+	local rc=$?
+	[[ -n $QEMU_PID ]] && kill "$QEMU_PID" 2>/dev/null
+	[[ -n $HEADSCALE_PID ]] && kill "$HEADSCALE_PID" 2>/dev/null
+	if [[ -n ${ARTIFACT_DIR:-} ]]; then
+		install -d "$ARTIFACT_DIR"
+		cp "$WORK/console.log" "$WORK/console.txt" "$WORK/headscale.log" "$WORK/mkinitcpio.log" \
+			"$WORK/setup.log" "$ARTIFACT_DIR/" 2>/dev/null || true
+	fi
+	rm -rf "$WORK"
+	fixtures_cleanup
+	return $rc
+}
+
+fixtures_init
+trap cleanup_all EXIT
+
+# --- what is under test ---------------------------------------------------
+if ((USE_INSTALLED)); then
+	[[ -f /usr/lib/initcpio/install/tailscale ]] ||
+		die '--installed given but the package is not installed'
+	SETUP_HELPER=/usr/bin/setup-initcpio-tailscale
+	HOOKDIR="$REPO_ROOT/tests/initcpio"
+	info 'testing the installed package'
+else
+	HOOKDIR="$WORK/hookdir"
+	install -d "$HOOKDIR/install" "$HOOKDIR/hooks"
+	install -m644 "$REPO_ROOT/initcpio-install-tailscale" "$HOOKDIR/install/tailscale"
+	install -m644 "$REPO_ROOT/initcpio-hooks-tailscale" "$HOOKDIR/hooks/tailscale"
+	install -m644 "$REPO_ROOT/tests/initcpio/install/testnet" "$HOOKDIR/install/testnet"
+	SETUP_HELPER="$REPO_ROOT/setup-initcpio-tailscale"
+	info 'testing the working tree'
+fi
+[[ -x $SETUP_HELPER ]] || die "setup helper not executable: $SETUP_HELPER"
+
+# --- kernel ---------------------------------------------------------------
+KVER=''
+for d in /usr/lib/modules/*/; do
+	[[ -f ${d}pkgbase ]] && KVER=$(basename "$d")
+done
+[[ -n $KVER ]] || die 'no kernel module tree found; install the linux package'
+KERNEL="/usr/lib/modules/$KVER/vmlinuz"
+[[ -f $KERNEL ]] || die "kernel image not found at $KERNEL"
+[[ -f /usr/lib/modules/$KVER/modules.dep ]] || depmod -a "$KVER"
+
+# --- control server -------------------------------------------------------
+# The guest reaches the container through QEMU's user-mode NAT, so the control
+# server has to be advertised on an address valid from both sides. The
+# container's own routable address satisfies that; 127.0.0.1 would not.
+HOST_IP=$(ip -4 route get 1.1.1.1 2>/dev/null | awk '{print $7; exit}')
+[[ -n $HOST_IP ]] || die 'could not determine the container IP address'
+SERVER_URL="http://${HOST_IP}:8080"
+info "control server will be advertised at $SERVER_URL"
+
+group 'start headscale'
+HEADSCALE=${HEADSCALE_BIN:-$WORK/headscale}
+if [[ ! -x $HEADSCALE ]]; then
+	url="https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_linux_amd64"
+	info "downloading headscale $HEADSCALE_VERSION"
+	curl -fsSL -o "$HEADSCALE" "$url" || die "failed to download $url"
+	chmod 755 "$HEADSCALE"
+fi
+
+CFG="$WORK/headscale.yaml"
+cat >"$CFG" <<-EOF
+	server_url: ${SERVER_URL}
+	listen_addr: 0.0.0.0:8080
+	metrics_listen_addr: 127.0.0.1:9090
+	grpc_listen_addr: 127.0.0.1:50443
+	grpc_allow_insecure: false
+	noise:
+	  private_key_path: ${WORK}/noise_private.key
+	prefixes:
+	  v4: 100.64.0.0/10
+	  v6: fd7a:115c:a1e0::/48
+	database:
+	  type: sqlite
+	  sqlite:
+	    path: ${WORK}/db.sqlite
+	# headscale refuses to start with an empty DERP map, so run its embedded
+	# relay rather than pointing at Tailscale's public one -- that keeps the
+	# test self-contained and off the internet.
+	derp:
+	  server:
+	    enabled: true
+	    region_id: 999
+	    region_code: ci
+	    region_name: CI
+	    stun_listen_addr: 0.0.0.0:3478
+	    private_key_path: ${WORK}/derp_server_private.key
+	    automatically_add_embedded_derp_region: true
+	  urls: []
+	  auto_update_enabled: false
+	  update_frequency: 24h
+	dns:
+	  magic_dns: false
+	  override_local_dns: false
+	  base_domain: ci.test
+	  nameservers:
+	    global: []
+	log:
+	  level: info
+	policy:
+	  mode: database
+EOF
+
+"$HEADSCALE" -c "$CFG" serve >"$WORK/headscale.log" 2>&1 &
+HEADSCALE_PID=$!
+
+for _ in $(seq 30); do
+	curl -fsS -o /dev/null "${SERVER_URL}/health" 2>/dev/null && break
+	kill -0 "$HEADSCALE_PID" 2>/dev/null || break
+	sleep 1
+done
+if curl -fsS -o /dev/null "${SERVER_URL}/health" 2>/dev/null; then
+	pass 'headscale is serving'
+else
+	fail 'headscale is serving' "$(tail -30 "$WORK/headscale.log")"
+	summary
+	exit 1
+fi
+
+hs() { "$HEADSCALE" -c "$CFG" "$@"; }
+
+hs users create ci >"$WORK/user.log" 2>&1 ||
+	die "headscale users create failed: $(cat "$WORK/user.log")"
+USER_ID=$(hs users list -o json 2>/dev/null | jq -r '.[] | select(.name=="ci") | .id')
+[[ -n $USER_ID ]] || die 'could not resolve the headscale user id'
+
+# The --user flag switched from name to id across headscale releases; try the
+# id first and fall back so a version bump does not silently break the test.
+AUTHKEY=$(hs preauthkeys create --user "$USER_ID" --reusable --expiration 24h 2>/dev/null | tail -1)
+if [[ -z $AUTHKEY || $AUTHKEY == *rror* ]]; then
+	AUTHKEY=$(hs preauthkeys create --user ci --reusable --expiration 24h 2>/dev/null | tail -1)
+fi
+[[ -n $AUTHKEY ]] || die 'could not create a headscale pre-auth key'
+pass 'headscale issued a pre-auth key'
+endgroup
+
+# --- the real setup helper ------------------------------------------------
+group 'setup-initcpio-tailscale against headscale'
+if "$SETUP_HELPER" \
+	--hostname="$TS_NODE_NAME" \
+	--login-server="$SERVER_URL" \
+	--authkey="$AUTHKEY" >"$WORK/setup.log" 2>&1; then
+	pass 'setup-initcpio-tailscale registers a node'
+else
+	fail 'setup-initcpio-tailscale registers a node' "$(cat "$WORK/setup.log")"
+	summary
+	exit 1
+fi
+
+check 'setup wrote tailscaled.state' test -s "$TS_SETUPDIR/tailscaled.state"
+check 'setup wrote default.env' test -s "$TS_SETUPDIR/default.env"
+
+node_known() {
+	hs nodes list -o json 2>/dev/null |
+		jq -e --arg n "$TS_NODE_NAME" '.[] | select(.given_name==$n)' >/dev/null
+}
+check 'the node is registered with headscale' node_known
+endgroup
+
+# --- build the image ------------------------------------------------------
+group 'build the boot image'
+install -d /etc/systemd/network
+cat >/etc/systemd/network/10-ci.network <<-'EOF'
+	[Match]
+	Name=en* eth*
+
+	[Network]
+	DHCP=yes
+EOF
+
+CONF="$WORK/mkinitcpio.conf"
+cat >"$CONF" <<-'EOF'
+	# tun is needed by tailscaled and the virtio drivers by the QEMU NIC.
+	# Listing them in MODULES both includes and autoloads them.
+	MODULES=(tun virtio_net virtio_pci)
+	BINARIES=()
+	FILES=()
+	HOOKS=(base systemd testnet tailscale)
+	COMPRESSION="cat"
+EOF
+
+IMG="$WORK/ci-initrd.img"
+# -D replaces the whole search path, so the stock directory must be named too.
+if mkinitcpio -n -D "$HOOKDIR" -D /usr/lib/initcpio \
+	-c "$CONF" -k "$KVER" -g "$IMG" >"$WORK/mkinitcpio.log" 2>&1; then
+	pass 'mkinitcpio builds the boot image'
+else
+	fail 'mkinitcpio builds the boot image' "$(tail -40 "$WORK/mkinitcpio.log")"
+	summary
+	exit 1
+fi
+endgroup
+
+# --- boot -----------------------------------------------------------------
+group 'boot under QEMU'
+
+node_online() {
+	hs nodes list -o json 2>/dev/null |
+		jq -e --arg n "$TS_NODE_NAME" '.[] | select(.given_name==$n) | select(.online==true)' \
+			>/dev/null
+}
+
+# setup-initcpio-tailscale ran a tailscaled of its own to register the node, and
+# headscale takes a moment to notice that session ending. Waiting for the node
+# to read as offline first is what makes the assertion below meaningful: once
+# it has, coming back online can only be the VM.
+info 'waiting for the setup-time session to drop'
+for _ in $(seq 24); do
+	node_online || break
+	sleep 5
+done
+if node_online; then
+	fail 'the node is offline before boot' \
+		'it still reads online, so the boot assertion would be vacuous'
+else
+	pass 'the node is offline before boot'
+fi
+
+ACCEL=tcg
+if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+	ACCEL=kvm
+else
+	warn 'no usable /dev/kvm; falling back to TCG emulation (slower)'
+fi
+info "booting with accel=$ACCEL"
+
+# No usable root device is provided on purpose. systemd still reaches
+# sysinit.target -- which is what pulls in tailscaled.service and networkd --
+# and then waits for a root filesystem that never appears, holding the VM up
+# long enough to observe the node from the control server.
+qemu-system-x86_64 \
+	-accel "$ACCEL" \
+	-m 1G -smp 2 \
+	-display none -no-reboot \
+	-kernel "$KERNEL" \
+	-initrd "$IMG" \
+	-append "console=ttyS0 root=/dev/disk/by-uuid/deadbeef-0000-0000-0000-000000000000 rw systemd.log_level=info" \
+	-netdev user,id=n0 \
+	-device virtio-net-pci,netdev=n0 \
+	-serial "file:$WORK/console.log" \
+	>"$WORK/qemu.log" 2>&1 &
+QEMU_PID=$!
+
+started=$SECONDS
+deadline=$((SECONDS + BOOT_TIMEOUT))
+online=0
+while ((SECONDS < deadline)); do
+	if node_online; then
+		online=1
+		break
+	fi
+	if ! kill -0 "$QEMU_PID" 2>/dev/null; then
+		warn 'QEMU exited before the node came online'
+		break
+	fi
+	sleep 5
+done
+
+if ((online)); then
+	pass "the initrd node came online after $((SECONDS - started))s"
+else
+	fail 'the initrd node came online' \
+		"$(printf 'last 40 lines of console:\n%s' "$(tail -40 "$WORK/console.log" 2>/dev/null)")"
+fi
+
+# Corroborating evidence from inside the guest, useful when the assertion above
+# fails and the question is how far the boot actually got. systemd colours its
+# console output, and the escape sequences land between "Started" and the unit
+# description, so they have to come out before matching.
+sed -r 's/\x1B\[[0-9;?]*[a-zA-Z]//g; s/\x1B\][^\x07]*(\x07|\x1B\\)//g' \
+	"$WORK/console.log" >"$WORK/console.txt" 2>/dev/null
+
+if grep -qE 'Started Tailscale node agent|tailscaled' "$WORK/console.txt"; then
+	pass 'the guest started the tailscaled unit'
+else
+	fail 'the guest started the tailscaled unit' \
+		"$(printf 'console.log is %s bytes; last 40 lines (de-escaped):\n%s' \
+			"$(stat -c %s "$WORK/console.log" 2>/dev/null || echo missing)" \
+			"$(tail -40 "$WORK/console.txt" 2>/dev/null)")"
+fi
+endgroup
+
+summary

--- a/tests/04-boot.sh
+++ b/tests/04-boot.sh
@@ -21,7 +21,17 @@ set -uo pipefail
 . "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
 . "$(dirname -- "${BASH_SOURCE[0]}")/fixtures.sh"
 
-HEADSCALE_VERSION=${HEADSCALE_VERSION:-0.26.1}
+# Pinned headscale release, with the sha256 of its linux_amd64 asset taken from
+# the checksums.txt published alongside it. Bumping the version means updating
+# the hash; overriding HEADSCALE_VERSION without also passing HEADSCALE_SHA256
+# skips verification and warns.
+HEADSCALE_PINNED_VERSION=0.26.1
+HEADSCALE_PINNED_SHA256=5012577e6fc5d4234aab7b4be0d6e271ea1a4ec38521a8aa472f80ea1fe81cba
+HEADSCALE_VERSION=${HEADSCALE_VERSION:-$HEADSCALE_PINNED_VERSION}
+if [[ -z ${HEADSCALE_SHA256:-} && $HEADSCALE_VERSION == "$HEADSCALE_PINNED_VERSION" ]]; then
+	HEADSCALE_SHA256=$HEADSCALE_PINNED_SHA256
+fi
+
 BOOT_TIMEOUT=${BOOT_TIMEOUT:-300}
 TS_NODE_NAME=${TS_NODE_NAME:-ci-initrd}
 
@@ -96,6 +106,18 @@ if [[ ! -x $HEADSCALE ]]; then
 	url="https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_linux_amd64"
 	info "downloading headscale $HEADSCALE_VERSION"
 	curl -fsSL -o "$HEADSCALE" "$url" || die "failed to download $url"
+
+	if [[ -n ${HEADSCALE_SHA256:-} ]]; then
+		got=$(sha256sum "$HEADSCALE" | cut -d' ' -f1)
+		[[ $got == "$HEADSCALE_SHA256" ]] ||
+			die "headscale checksum mismatch
+       expected $HEADSCALE_SHA256
+       got      $got"
+		pass 'the headscale download matches its pinned checksum'
+	else
+		warn "no checksum pinned for headscale $HEADSCALE_VERSION; skipping verification"
+	fi
+
 	chmod 755 "$HEADSCALE"
 fi
 
@@ -200,8 +222,13 @@ endgroup
 
 # --- build the image ------------------------------------------------------
 group 'build the boot image'
-install -d /etc/systemd/network
-cat >/etc/systemd/network/10-ci.network <<-'EOF'
+# Kept in $WORK and handed to the hook via TESTNET_CONFIG rather than written
+# to /etc/systemd/network: with ALLOW_UNSAFE=1 this script can be run on a real
+# host, where leaving a DHCP .network file behind would persistently affect
+# systemd-networkd.
+TESTNET_CONFIG="$WORK/10-ci.network"
+export TESTNET_CONFIG
+cat >"$TESTNET_CONFIG" <<-'EOF'
 	[Match]
 	Name=en* eth*
 

--- a/tests/container.sh
+++ b/tests/container.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Runs the test suite in a throwaway Arch container, so it never touches the
+# host's /etc/initcpio/tailscale or installed packages.
+#
+#   tests/container.sh              # 01-lint, 02-package, 03-initramfs
+#   tests/container.sh all          # plus the QEMU boot test
+#   tests/container.sh 01 02        # a subset
+#
+# Uses podman if available, otherwise docker. CI does not call this script --
+# it runs tests/NN-*.sh directly in its own container -- but the package set
+# below is kept in step with the workflow so local and CI runs match.
+set -euo pipefail
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd -- "$HERE/.." && pwd)
+IMAGE=${IMAGE:-docker.io/library/archlinux:base-devel}
+
+ENGINE=${ENGINE:-}
+if [[ -z $ENGINE ]]; then
+	ENGINE=$(command -v podman || command -v docker) ||
+		{ echo 'neither podman nor docker found' >&2; exit 1; }
+fi
+
+STAGES=("$@")
+((${#STAGES[@]})) || STAGES=(01 02 03)
+WANTS_ALL=0
+[[ ${STAGES[0]} == all ]] && WANTS_ALL=1
+
+# Only install what the requested stages need; pulling the kernel and QEMU for
+# a lint run would be a waste.
+PKGS=(git)
+want() {
+	((WANTS_ALL)) && return 0
+	local s
+	for s in "${STAGES[@]}"; do [[ $s == "$1"* ]] && return 0; done
+	return 1
+}
+want 01 && PKGS+=(shellcheck mkinitcpio)
+want 02 && PKGS+=(pacman-contrib namcap)
+want 03 && PKGS+=(mkinitcpio linux tailscale iptables openssh)
+want 04 && PKGS+=(mkinitcpio linux tailscale iptables openssh qemu-base jq curl)
+
+RUN_OPTS=()
+[[ -t 0 && -t 1 ]] && RUN_OPTS+=(-it)
+
+# Somewhere for the tests to leave console/build logs behind on failure.
+if [[ -n ${ARTIFACT_DIR:-} ]]; then
+	mkdir -p "$ARTIFACT_DIR"
+	RUN_OPTS+=(-v "$(cd "$ARTIFACT_DIR" && pwd):/artifacts:rw" -e ARTIFACT_DIR=/artifacts)
+fi
+
+if ((WANTS_ALL)) || want 04; then
+	# QEMU is dramatically faster with hardware acceleration; the boot test
+	# falls back to TCG when this is not available.
+	[[ -e /dev/kvm ]] && RUN_OPTS+=(--device /dev/kvm)
+fi
+
+exec "$ENGINE" run --rm "${RUN_OPTS[@]}" \
+	-v "$REPO:/src:ro" -w /src \
+	-e "STAGES=${STAGES[*]}" \
+	"$IMAGE" \
+	bash -euo pipefail -c '
+		# Installing a kernel triggers mkinitcpio -P against the stock preset,
+		# which cannot work in a container (autodetect needs the real host).
+		# Disabling just that hook keeps 60-depmod.hook, which the tests need.
+		install -d /etc/pacman.d/hooks
+		ln -sf /dev/null /etc/pacman.d/hooks/90-mkinitcpio-install.hook
+
+		# mkinitcpio is named explicitly because the linux package depends on
+		# the virtual "initramfs" provider and --noconfirm would otherwise be
+		# free to pick dracut.
+		pacman -Syu --noconfirm --needed '"${PKGS[*]}"' >/dev/null
+
+		# makepkg refuses to run as root; tests/run.sh drops to this user.
+		useradd -m builder 2>/dev/null || true
+
+		exec /src/tests/run.sh $STAGES
+	'

--- a/tests/container.sh
+++ b/tests/container.sh
@@ -6,9 +6,10 @@
 #   tests/container.sh all          # plus the QEMU boot test
 #   tests/container.sh 01 02        # a subset
 #
-# Uses podman if available, otherwise docker. CI does not call this script --
-# it runs tests/NN-*.sh directly in its own container -- but the package set
-# below is kept in step with the workflow so local and CI runs match.
+# Uses podman if available, otherwise docker. CI's lint, package and initramfs
+# jobs run tests/NN-*.sh directly in an Arch `container:` job, so the package set
+# below is kept in step with the workflow. The boot job does call this script,
+# so that --device /dev/kvm is only passed when the runner actually has KVM.
 set -euo pipefail
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO=$(cd -- "$HERE/.." && pwd)

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Fixture management for tests that exercise the install hook.
+#
+# The install hook hardcodes /etc/initcpio/tailscale with no override, so tests
+# have to write there for real. On a developer machine that directory holds a
+# live Tailscale node key, so `fixtures_init` refuses to run outside a container
+# unless ALLOW_UNSAFE=1, and always moves any pre-existing directory aside and
+# restores it on exit.
+#
+# shellcheck shell=bash
+
+TS_SETUPDIR=/etc/initcpio/tailscale
+FIXTURE_BACKUP=''
+FIXTURE_SRC=''
+
+in_container() {
+	[[ -e /run/.containerenv || -e /.dockerenv ]] && return 0
+	[[ -n ${GITHUB_ACTIONS:-} && -n ${container:-} ]] && return 0
+	local virt
+	virt=$(systemd-detect-virt -c 2>/dev/null) && [[ $virt != none ]]
+}
+
+fixtures_init() {
+	if [[ ${ALLOW_UNSAFE:-0} != 1 ]] && ! in_container; then
+		die "refusing to run outside a container: this would clobber $TS_SETUPDIR (your real node key).
+       Use tests/container.sh, or set ALLOW_UNSAFE=1 if you really mean it."
+	fi
+	[[ $(id -u) == 0 ]] || die 'fixtures require root'
+
+	# Stash any real configuration and put it back however we exit.
+	if [[ -e $TS_SETUPDIR ]]; then
+		FIXTURE_BACKUP=$(mktemp -d)
+		mv "$TS_SETUPDIR" "$FIXTURE_BACKUP/tailscale"
+		warn "moved existing $TS_SETUPDIR aside; it will be restored on exit"
+	fi
+	FIXTURE_SRC=$(mktemp -d)
+	trap fixtures_cleanup EXIT
+}
+
+fixtures_cleanup() {
+	local rc=$?
+	rm -rf "$TS_SETUPDIR"
+	if [[ -n $FIXTURE_BACKUP ]]; then
+		mv "$FIXTURE_BACKUP/tailscale" "$TS_SETUPDIR"
+		rm -rf "$FIXTURE_BACKUP"
+	fi
+	[[ -n $FIXTURE_SRC ]] && rm -rf "$FIXTURE_SRC"
+	return $rc
+}
+
+# fixtures_write [--ssh]
+#
+# Populates $TS_SETUPDIR the way setup-initcpio-tailscale would, and keeps a
+# pristine copy under $FIXTURE_SRC so tests can byte-compare what ended up in
+# the image against what went in.
+fixtures_write() {
+	local with_ssh=0
+	[[ ${1:-} == --ssh ]] && with_ssh=1
+
+	rm -rf "$TS_SETUPDIR" "${FIXTURE_SRC:?}"/*
+	install -dm700 "$TS_SETUPDIR"
+
+	# Shape mimics a real tailscaled state file; the hook only requires that it
+	# be readable and non-empty, but using plausible content keeps failures legible.
+	printf '{"_machinekey":"privkey:%064d","_profiles":"[]"}\n' 1 >"$FIXTURE_SRC/tailscaled.state"
+	printf 'PORT="41641"\nFLAGS=""\n' >"$FIXTURE_SRC/default.env"
+	install -m644 -t "$TS_SETUPDIR" "$FIXTURE_SRC/tailscaled.state" "$FIXTURE_SRC/default.env"
+
+	if ((with_ssh)); then
+		# ssh-keygen -A writes into <prefix>/etc/ssh and will not create it.
+		install -dm700 "$FIXTURE_SRC/ssh" "$FIXTURE_SRC/etc/ssh"
+		ssh-keygen -q -A -f "$FIXTURE_SRC" >/dev/null
+		mv "$FIXTURE_SRC"/etc/ssh/ssh_host_* "$FIXTURE_SRC/ssh/"
+		rm -rf "${FIXTURE_SRC:?}/etc"
+		install -dm700 "$TS_SETUPDIR/ssh"
+		install -m600 -t "$TS_SETUPDIR/ssh" "$FIXTURE_SRC/ssh/"ssh_host_*_key
+		install -m644 -t "$TS_SETUPDIR/ssh" "$FIXTURE_SRC/ssh/"ssh_host_*_key.pub
+	fi
+}

--- a/tests/initcpio/install/testnet
+++ b/tests/initcpio/install/testnet
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Test-only mkinitcpio hook: brings systemd-networkd up inside the initramfs so
+# the QEMU guest in tests/04-boot.sh can reach the control server.
+#
+# This stands in for the sd-network hook from mkinitcpio-systemd-extras, which
+# lives in the AUR. Depending on an AUR build would make CI slower and give the
+# boot test a way to fail for reasons that have nothing to do with this package.
+#
+# It is scaffolding for the test suite and is not part of the shipped package.
+
+build() {
+	add_systemd_unit systemd-networkd.service
+	add_systemd_unit systemd-networkd.socket
+
+	# DefaultDependencies=no on tailscaled.service means it can start before the
+	# network exists, so networkd has to come up in sysinit.target alongside it.
+	add_symlink /etc/systemd/system/sysinit.target.wants/systemd-networkd.service \
+		/usr/lib/systemd/system/systemd-networkd.service
+
+	add_file "${TESTNET_CONFIG:-/etc/systemd/network/10-ci.network}" \
+		/etc/systemd/network/10-ci.network
+
+	# systemd-networkd.service drops privileges to this user.
+	local db
+	for db in passwd group shadow; do
+		grep "^systemd-network:" "/etc/$db" >>"$BUILDROOT/etc/$db" 2>/dev/null
+	done
+
+	return 0
+}
+
+help() {
+	cat <<-__EOF_HELP__
+		Test-only hook. Enables systemd-networkd inside the initramfs and copies a
+		single .network file, so the boot test's guest can get an address from
+		QEMU's user-mode DHCP. Not for production use.
+	__EOF_HELP__
+}
+
+# vim: noexpandtab

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Shared helpers for the mkinitcpio-tailscale test suite.
+#
+# Source this from a test script:
+#
+#   . "$(dirname "$0")/lib.sh"
+#
+# It provides logging, a pass/fail tally, and assertions for poking at an
+# extracted initramfs image. Call `summary` at the end and exit with its status.
+#
+# shellcheck shell=bash
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+export REPO_ROOT
+
+if [[ -t 1 && -z ${NO_COLOR:-} ]]; then
+	C_RED=$'\e[31m' C_GREEN=$'\e[32m' C_YELLOW=$'\e[33m' C_BOLD=$'\e[1m' C_OFF=$'\e[0m'
+else
+	C_RED='' C_GREEN='' C_YELLOW='' C_BOLD='' C_OFF=''
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+FAILED_NAMES=()
+
+info() { printf '%s==> %s%s\n' "$C_BOLD" "$*" "$C_OFF"; }
+warn() { printf '%s==> WARNING: %s%s\n' "$C_YELLOW" "$*" "$C_OFF" >&2; }
+die() {
+	printf '%s==> ERROR: %s%s\n' "$C_RED" "$*" "$C_OFF" >&2
+	exit 1
+}
+
+# Collapsible sections in the GitHub Actions log, plain headings elsewhere.
+group() {
+	if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+		printf '::group::%s\n' "$*"
+	else
+		info "$*"
+	fi
+}
+endgroup() {
+	if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+		printf '::endgroup::\n'
+	fi
+}
+
+# Indent captured command output so it reads as a detail of the failure above it.
+_detail() {
+	[[ -n ${1:-} ]] || return 0
+	printf '       %s\n' "${1//$'\n'/$'\n'       }"
+}
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sok%s   %s\n' "$C_GREEN" "$C_OFF" "$1"
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	FAILED_NAMES+=("$1")
+	printf '  %sFAIL%s %s\n' "$C_RED" "$C_OFF" "$1"
+	_detail "${2:-}"
+	if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+		printf '::error::%s\n' "$1"
+	fi
+	return 0
+}
+
+summary() {
+	printf '\n'
+	if ((TESTS_FAILED)); then
+		printf '%s%d of %d checks failed%s\n' "$C_RED" "$TESTS_FAILED" "$TESTS_RUN" "$C_OFF"
+		printf '  - %s\n' "${FAILED_NAMES[@]}"
+		return 1
+	fi
+	printf '%s%d checks passed%s\n' "$C_GREEN" "$TESTS_RUN" "$C_OFF"
+	return 0
+}
+
+# --- generic assertions ----------------------------------------------------
+
+# check <description> <command...> — the command must exit 0
+check() {
+	local desc=$1 out rc
+	shift
+	out=$("$@" 2>&1)
+	rc=$?
+	if ((rc == 0)); then
+		pass "$desc"
+	else
+		fail "$desc" "\$ $* (exit $rc)"
+		_detail "$out"
+	fi
+}
+
+# check_fails <description> <command...> — the command must exit non-zero
+check_fails() {
+	local desc=$1 out rc
+	shift
+	out=$("$@" 2>&1)
+	rc=$?
+	if ((rc != 0)); then
+		pass "$desc"
+	else
+		fail "$desc" "command unexpectedly succeeded: $*"
+		_detail "$out"
+	fi
+}
+
+# --- assertions against an extracted image root ----------------------------
+#
+# All of these take the extraction root as $1 and a path relative to it as $2,
+# so failures report the in-image path the reader actually cares about.
+
+# img_has <root> <relpath> — path exists (regular file, dir or symlink)
+img_has() {
+	local root=$1 rel=$2
+	if [[ -e $root/$rel || -L $root/$rel ]]; then
+		pass "image contains /$rel"
+	else
+		fail "image contains /$rel" 'no such path in the image'
+	fi
+}
+
+# img_lacks <root> <relpath> — path must NOT exist
+img_lacks() {
+	local root=$1 rel=$2
+	if [[ -e $root/$rel || -L $root/$rel ]]; then
+		fail "image does not contain /$rel" 'path is present but should not be'
+	else
+		pass "image does not contain /$rel"
+	fi
+}
+
+# img_has_glob <root> <glob> <description> — at least one match
+img_has_glob() {
+	local root=$1 glob=$2 desc=$3 matches
+	# shellcheck disable=SC2086 # deliberate glob expansion
+	matches=$(compgen -G "$root/$glob") || matches=''
+	if [[ -n $matches ]]; then
+		pass "$desc"
+	else
+		fail "$desc" "no match for /$glob"
+	fi
+}
+
+# img_symlink <root> <relpath> <expected target>
+img_symlink() {
+	local root=$1 rel=$2 want=$3 got
+	if [[ ! -L $root/$rel ]]; then
+		fail "/$rel is a symlink to $want" 'not a symlink (or missing)'
+		return 0
+	fi
+	got=$(readlink "$root/$rel")
+	if [[ $got == "$want" ]]; then
+		pass "/$rel is a symlink to $want"
+	else
+		fail "/$rel is a symlink to $want" "points at '$got' instead"
+	fi
+}
+
+# img_grep <root> <relpath> <extended regex>
+img_grep() {
+	local root=$1 rel=$2 re=$3
+	if [[ ! -f $root/$rel ]]; then
+		fail "/$rel matches /$re/" 'file missing from the image'
+		return 0
+	fi
+	if grep -Eq -- "$re" "$root/$rel"; then
+		pass "/$rel matches /$re/"
+	else
+		fail "/$rel matches /$re/" "$(printf 'file contents:\n%s' "$(cat "$root/$rel")")"
+	fi
+}
+
+# img_same <root> <relpath> <reference file> — byte-identical
+img_same() {
+	local root=$1 rel=$2 ref=$3
+	if [[ ! -f $root/$rel ]]; then
+		fail "/$rel matches $ref" 'file missing from the image'
+		return 0
+	fi
+	if cmp -s "$root/$rel" "$ref"; then
+		pass "/$rel matches $(basename "$ref")"
+	else
+		fail "/$rel matches $(basename "$ref")" "$(diff -u "$ref" "$root/$rel" || true)"
+	fi
+}
+
+# --- environment guards ----------------------------------------------------
+
+need_cmd() {
+	local c
+	for c; do
+		command -v "$c" >/dev/null 2>&1 || die "required command not found: $c"
+	done
+}
+
+need_root() {
+	[[ $(id -u) == 0 ]] || die "$(basename "$0") must run as root (try tests/container.sh)"
+}
+
+need_pkg() {
+	local p
+	for p; do
+		pacman -Qq "$p" >/dev/null 2>&1 || die "required package not installed: $p"
+	done
+}
+
+# Path to the busybox mkinitcpio ships; its ash is what runs /init in a
+# busybox-based initramfs, so it is the right interpreter to syntax-check
+# the runtime hook against.
+initcpio_busybox() {
+	if [[ -x /usr/lib/initcpio/busybox ]]; then
+		printf '/usr/lib/initcpio/busybox\n'
+	elif command -v busybox >/dev/null 2>&1; then
+		command -v busybox
+	else
+		return 1
+	fi
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Runs test stages in order and reports a combined result.
+#
+#   tests/run.sh                 # 01-lint, 02-package, 03-initramfs
+#   tests/run.sh all             # the above plus 04-boot
+#   tests/run.sh 03 04           # just those, by prefix or full name
+#
+# 04-boot is excluded by default because it downloads headscale and boots QEMU.
+set -uo pipefail
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
+DEFAULT_STAGES=(01-lint 02-package 03-initramfs)
+ALL_STAGES=(01-lint 02-package 03-initramfs 04-boot)
+
+resolve_stage() {
+	local want=$1 s
+	for s in "${ALL_STAGES[@]}"; do
+		[[ $s == "$want" || $s == "$want"-* ]] && {
+			printf '%s\n' "$s"
+			return 0
+		}
+	done
+	return 1
+}
+
+STAGES=()
+if (($# == 0)); then
+	STAGES=("${DEFAULT_STAGES[@]}")
+elif [[ $1 == all ]]; then
+	STAGES=("${ALL_STAGES[@]}")
+else
+	for a in "$@"; do
+		s=$(resolve_stage "$a") || {
+			printf 'unknown stage: %s (known: %s)\n' "$a" "${ALL_STAGES[*]}" >&2
+			exit 2
+		}
+		STAGES+=("$s")
+	done
+fi
+
+# makepkg refuses to run as root, so when the suite is driven as root (the
+# normal case in a container) the packaging stage drops to an unprivileged user.
+run_stage() {
+	local stage=$1 script="$HERE/$1.sh"
+	if [[ $stage == 02-package && $(id -u) == 0 ]]; then
+		id builder >/dev/null 2>&1 ||
+			{ printf 'skipping 02-package: running as root and no "builder" user exists\n' >&2; return 0; }
+		runuser -u builder -- "$script"
+	else
+		"$script"
+	fi
+}
+
+FAILED=()
+for stage in "${STAGES[@]}"; do
+	printf '\n\033[1m########## %s ##########\033[0m\n' "$stage"
+	run_stage "$stage" || FAILED+=("$stage")
+done
+
+printf '\n\033[1m########## result ##########\033[0m\n'
+if ((${#FAILED[@]})); then
+	printf '\033[31mfailed stages: %s\033[0m\n' "${FAILED[*]}"
+	exit 1
+fi
+printf '\033[32mall stages passed: %s\033[0m\n' "${STAGES[*]}"


### PR DESCRIPTION
Adds CI for the hook, plus a local test runner that uses the same scripts.

## Jobs

| Job | What it proves |
|---|---|
| **lint** | shellcheck (advisory — see below), plus blocking `bash -n`, busybox `ash -n` on the runtime hook, and hook contract checks |
| **package** | `sha256sums`/`.SRCINFO` drift, `makepkg`, `namcap`, exact payload paths and modes, packaged files identical to source. Uploads the `.pkg.tar.zst` |
| **initramfs** | Builds real images for the systemd, busybox and Tailscale SSH variants and asserts on their contents |
| **boot** | Throwaway headscale → real `setup-initcpio-tailscale` → `mkinitcpio` → QEMU boot → node observed online from the control server |

## Running it locally

The workflow YAML only installs packages and calls one script per job; everything else is in `tests/*.sh`.

```sh
make test        # lint, package, initramfs
make test-all    # adds the QEMU boot test
./tests/container.sh 03      # a single stage
```

Tests run in a throwaway Arch container because the install hook hardcodes `/etc/initcpio/tailscale`, which holds a real node key on a developer machine. `tests/fixtures.sh` refuses to run outside a container and restores any pre-existing config on exit.

## Notes

The boot test is the interesting one: it registers a node against a local headscale, builds an image from that state, boots it, and then asserts from headscale's side. That covers the whole chain the package claims, and gives `setup-initcpio-tailscale` its only coverage via the non-interactive `--authkey` path. It uses headscale's embedded DERP so it stays self-contained, and waits for the node to read *offline* before booting — without that gate the assertion passed vacuously off the setup-time session.

`tests/initcpio/install/testnet` is test-only scaffolding standing in for `sd-network`, which is AUR-only. Depending on an AUR build would make CI slower and give the boot test ways to fail unrelated to this package.

shellcheck is advisory and never fails the build, so the five pre-existing findings are left alone and `PKGBUILD`/`.SRCINFO` are untouched.

## Known gap, not addressed here

The guard clauses in `initcpio-install-tailscale` print an error but do not stop the build: mkinitcpio's `run_build_hook` deliberately discards `build()`'s return value, and only failures inside `add_*` bump `_builderrors`. So a user who has not run `setup-initcpio-tailscale` gets the error, `mkinitcpio -P` still exits 0, and the resulting initramfs silently has no Tailscale.

The tests assert the contract as it behaves today — the error is printed, and no half-configured image is produced — and carry a comment pointing at the stock fix (`builderrors=$(( ++_builderrors ))` before `return 1`, as in the `acpi_override` hook). Worth fixing separately, after this lands.