### PR TITLE
Make shellcheck findings fail the lint stage

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -9,8 +9,8 @@ pkgbase = mkinitcpio-tailscale
 	source = initcpio-hooks-tailscale
 	source = initcpio-install-tailscale
 	source = setup-initcpio-tailscale
-	sha256sums = ce5df937e08ee7791921aad719413640aca445083694b2f526008a8ad53d4155
-	sha256sums = 68d6a305f950f944e858f02032347ea9d3139a873effb67242fdcb2c06cae7ea
-	sha256sums = 745a12f097fcfe4a3b6b5a76e6b43fefa84efc93628131b8c87a8a40cd45545f
+	sha256sums = fc322878c59232bd92043b9aa3827cee40704937d9ecf0ebe1a66174f990cb3e
+	sha256sums = 2e63c9a69ec45322f2166a23f73b2bc79cb269c7526b1e2729c84917e72f3206
+	sha256sums = 63fd44cd09e73fbb35107328c3f0b69c9ffc9ea30083753b85c51f62261d9671
 
 pkgname = mkinitcpio-tailscale

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,12 +11,12 @@ depends=("mkinitcpio")
 source=("initcpio-hooks-tailscale"
   "initcpio-install-tailscale"
   "setup-initcpio-tailscale")
-sha256sums=('ce5df937e08ee7791921aad719413640aca445083694b2f526008a8ad53d4155'
-            '68d6a305f950f944e858f02032347ea9d3139a873effb67242fdcb2c06cae7ea'
-            '745a12f097fcfe4a3b6b5a76e6b43fefa84efc93628131b8c87a8a40cd45545f')
+sha256sums=('fc322878c59232bd92043b9aa3827cee40704937d9ecf0ebe1a66174f990cb3e'
+            '2e63c9a69ec45322f2166a23f73b2bc79cb269c7526b1e2729c84917e72f3206'
+            '63fd44cd09e73fbb35107328c3f0b69c9ffc9ea30083753b85c51f62261d9671')
 
 package() {
-  install -m 644 -D ${srcdir}/initcpio-hooks-tailscale ${pkgdir}/usr/lib/initcpio/hooks/tailscale
-  install -m 644 -D ${srcdir}/initcpio-install-tailscale ${pkgdir}/usr/lib/initcpio/install/tailscale
-  install -m 755 -D ${srcdir}/setup-initcpio-tailscale ${pkgdir}/usr/bin/setup-initcpio-tailscale
+  install -m 644 -D "${srcdir}/initcpio-hooks-tailscale" "${pkgdir}/usr/lib/initcpio/hooks/tailscale"
+  install -m 644 -D "${srcdir}/initcpio-install-tailscale" "${pkgdir}/usr/lib/initcpio/install/tailscale"
+  install -m 755 -D "${srcdir}/setup-initcpio-tailscale" "${pkgdir}/usr/bin/setup-initcpio-tailscale"
 }

--- a/initcpio-hooks-tailscale
+++ b/initcpio-hooks-tailscale
@@ -2,6 +2,8 @@
 
 run_hook() (
   echo "Starting Tailscale"
+  # Written into the image by the install hook; not present at lint time.
+  # shellcheck source=/dev/null
   . /etc/default/tailscaled
 
   mkdir /dev/pts
@@ -9,6 +11,9 @@ run_hook() (
 
   # Launch tailscale agent in the background
   /usr/sbin/tailscaled --cleanup
+  # FLAGS holds extra tailscaled arguments from default.env and is meant to
+  # word-split; quoting it would pass the whole string as a single argument.
+  # shellcheck disable=SC2086
   /usr/sbin/tailscaled \
     --state=/var/lib/tailscale/tailscaled.state \
     --socket=/run/tailscale/tailscaled.sock \

--- a/initcpio-install-tailscale
+++ b/initcpio-install-tailscale
@@ -26,8 +26,9 @@ build() {
 
 	# Copy ssh host keys if they exist
 	if [[ -d ${setupdir}/ssh ]]; then
-		for f in $(ls -A ${setupdir}/ssh); do
-			add_file ${setupdir}/ssh/${f} /var/lib/tailscale/ssh/
+		for f in "${setupdir}"/ssh/*; do
+			[[ -e $f ]] || continue
+			add_file "$f" /var/lib/tailscale/ssh/
 		done
 	fi
 

--- a/setup-initcpio-tailscale
+++ b/setup-initcpio-tailscale
@@ -67,7 +67,7 @@ socket="${SETUPDIR}/tailscaled.sock"
 state="${SETUPDIR}/tailscaled.state"
 
 if [[ $FOUND_SSH_IN_ARGS == yes ]]; then
-  mkdir -p ${SETUPDIR}/etc/ssh
+  mkdir -p "${SETUPDIR}/etc/ssh"
   ssh-keygen -A -f "${SETUPDIR}"
 fi
 

--- a/tests/01-lint.sh
+++ b/tests/01-lint.sh
@@ -26,7 +26,7 @@ sc_out=$(shellcheck -x "${SCRIPTS[@]}" "${TEST_SCRIPTS[@]}" 2>&1) && sc_rc=0 || 
 pkg_out=$(shellcheck --shell=bash --exclude=SC2034,SC2154 PKGBUILD 2>&1) && pkg_rc=0 || pkg_rc=$?
 
 if ((sc_rc == 0 && pkg_rc == 0)); then
-	pass 'shellcheck is clean'
+	pass 'shellcheck reports no findings'
 else
 	printf '%s\n' "$sc_out" "$pkg_out"
 	if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
@@ -36,7 +36,7 @@ else
 			printf '```\n'
 		} >>"$GITHUB_STEP_SUMMARY"
 	fi
-	fail 'shellcheck is clean' 'see the findings above'
+	fail 'shellcheck reports no findings' 'see the findings above'
 fi
 endgroup
 

--- a/tests/01-lint.sh
+++ b/tests/01-lint.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Static checks.
 #
-# Findings from shellcheck are advisory: they are printed (and surfaced in the
-# job summary on CI) but never fail the run. Syntax errors are different --
-# a script that does not parse is unambiguously broken, so `bash -n` and the
-# busybox `ash -n` check are blocking.
+# Everything here is blocking, shellcheck included. Where a finding is a false
+# positive the suppression lives at the offending line with a comment saying
+# why, rather than being filtered out globally.
+# shellcheck source-path=SCRIPTDIR
 set -uo pipefail
 . "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
 
@@ -13,28 +13,30 @@ cd "$REPO_ROOT" || die "cannot cd to $REPO_ROOT"
 SCRIPTS=(initcpio-install-tailscale initcpio-hooks-tailscale setup-initcpio-tailscale)
 TEST_SCRIPTS=(tests/*.sh)
 
-group 'shellcheck (advisory)'
-if command -v shellcheck >/dev/null 2>&1; then
-	sc_out=$(shellcheck "${SCRIPTS[@]}" "${TEST_SCRIPTS[@]}" 2>&1) || true
-	# SC2034/SC2154 are structural in a PKGBUILD (makepkg assigns and consumes
-	# these), so they are excluded rather than reported as noise every run.
-	pkgbuild_out=$(shellcheck --shell=bash --exclude=SC2034,SC2154 PKGBUILD 2>&1) || true
+group 'shellcheck'
+command -v shellcheck >/dev/null 2>&1 ||
+	die 'shellcheck is required; install the shellcheck package'
 
-	if [[ -n $sc_out || -n $pkgbuild_out ]]; then
-		printf '%s\n' "$sc_out" "$pkgbuild_out"
-		if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
-			{
-				printf '### shellcheck (advisory)\n\n```\n'
-				printf '%s\n' "$sc_out" "$pkgbuild_out"
-				printf '```\n'
-			} >>"$GITHUB_STEP_SUMMARY"
-		fi
-		warn 'shellcheck reported findings (not failing the build)'
-	else
-		info 'shellcheck is clean'
-	fi
+# -x follows sourced files, which together with the source-path=SCRIPTDIR
+# directive in each test script lets shellcheck see lib.sh and fixtures.sh.
+sc_out=$(shellcheck -x "${SCRIPTS[@]}" "${TEST_SCRIPTS[@]}" 2>&1) && sc_rc=0 || sc_rc=$?
+
+# SC2034/SC2154 are structural in a PKGBUILD: makepkg assigns and consumes
+# these, so shellcheck cannot see either end of them.
+pkg_out=$(shellcheck --shell=bash --exclude=SC2034,SC2154 PKGBUILD 2>&1) && pkg_rc=0 || pkg_rc=$?
+
+if ((sc_rc == 0 && pkg_rc == 0)); then
+	pass 'shellcheck is clean'
 else
-	warn 'shellcheck not installed; skipping'
+	printf '%s\n' "$sc_out" "$pkg_out"
+	if [[ -n ${GITHUB_STEP_SUMMARY:-} ]]; then
+		{
+			printf '### shellcheck\n\n```\n'
+			printf '%s\n' "$sc_out" "$pkg_out"
+			printf '```\n'
+		} >>"$GITHUB_STEP_SUMMARY"
+	fi
+	fail 'shellcheck is clean' 'see the findings above'
 fi
 endgroup
 

--- a/tests/02-package.sh
+++ b/tests/02-package.sh
@@ -8,6 +8,7 @@
 # makepkg refuses to run as root, and that guard covers --printsrcinfo and the
 # `makepkg -g` that updpkgsums shells out to, so this whole script must run
 # unprivileged.
+# shellcheck source-path=SCRIPTDIR
 set -uo pipefail
 . "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
 

--- a/tests/03-initramfs.sh
+++ b/tests/03-initramfs.sh
@@ -5,6 +5,7 @@
 # mkinitcpio's -D flag, so this needs nothing installed and is fast to iterate
 # on. Pass --installed to test /usr/lib/initcpio/{install,hooks}/tailscale as
 # laid down by the built package instead.
+# shellcheck source-path=SCRIPTDIR
 set -uo pipefail
 . "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
 . "$(dirname -- "${BASH_SOURCE[0]}")/fixtures.sh"

--- a/tests/04-boot.sh
+++ b/tests/04-boot.sh
@@ -17,6 +17,7 @@
 #
 #   --installed   test /usr/lib/initcpio/... and /usr/bin/setup-initcpio-tailscale
 #                 from the built package instead of the working tree
+# shellcheck source-path=SCRIPTDIR
 set -uo pipefail
 . "$(dirname -- "${BASH_SOURCE[0]}")/lib.sh"
 . "$(dirname -- "${BASH_SOURCE[0]}")/fixtures.sh"

--- a/tests/container.sh
+++ b/tests/container.sh
@@ -55,9 +55,13 @@ if ((WANTS_ALL)) || want 04; then
 	[[ -e /dev/kvm ]] && RUN_OPTS+=(--device /dev/kvm)
 fi
 
+# PKGS and STAGES are passed in as environment variables and expanded by the
+# shell inside the container, so the script below is deliberately single-quoted.
+# shellcheck disable=SC2016
 exec "$ENGINE" run --rm "${RUN_OPTS[@]}" \
 	-v "$REPO:/src:ro" -w /src \
 	-e "STAGES=${STAGES[*]}" \
+	-e "PKGS=${PKGS[*]}" \
 	"$IMAGE" \
 	bash -euo pipefail -c '
 		# Installing a kernel triggers mkinitcpio -P against the stock preset,
@@ -69,7 +73,7 @@ exec "$ENGINE" run --rm "${RUN_OPTS[@]}" \
 		# mkinitcpio is named explicitly because the linux package depends on
 		# the virtual "initramfs" provider and --noconfirm would otherwise be
 		# free to pick dracut.
-		pacman -Syu --noconfirm --needed '"${PKGS[*]}"' >/dev/null
+		pacman -Syu --noconfirm --needed $PKGS >/dev/null
 
 		# makepkg refuses to run as root; tests/run.sh drops to this user.
 		useradd -m builder 2>/dev/null || true


### PR DESCRIPTION
Flips shellcheck from advisory to blocking, and fixes the findings that were being grandfathered in.

## The findings

One was a real latent bug. The install hook iterated `$(ls -A ...)` over the SSH host key directory, so any filename containing whitespace would word-split into bogus paths:

```bash
-               for f in $(ls -A ${setupdir}/ssh); do
-                       add_file ${setupdir}/ssh/${f} /var/lib/tailscale/ssh/
+               for f in "${setupdir}"/ssh/*; do
+                       [[ -e $f ]] || continue
+                       add_file "$f" /var/lib/tailscale/ssh/
```

That also stops the hook shelling out to `ls` from a file mkinitcpio sources. The rest were quoting: `${SETUPDIR}` in the setup helper, and `${srcdir}`/`${pkgdir}` in `PKGBUILD` — the latter being the Arch packaging guideline regardless.

Two are false positives, suppressed at the line with a comment rather than filtered globally:

- the runtime hook sources `/etc/default/tailscaled`, which only exists inside the image (SC1091)
- `${FLAGS}` in that same file **must** word-split — it carries extra `tailscaled` arguments out of `default.env`, so quoting it would pass the whole string as one argument (SC2086)

## Lint changes

shellcheck now fails the stage, and runs with `-x` so sourced files are followed. The test scripts carry `# shellcheck source-path=SCRIPTDIR` above the first command — placement matters, since a directive after a command applies only to the next command, which is why `lib.sh` resolved but `fixtures.sh` didn't.

`SC2034`/`SC2154` remain excluded for `PKGBUILD` alone, where makepkg assigns and consumes those variables and shellcheck can see neither end.

## Verification

Full suite green: 18 lint + 10 package + 76 initramfs + 11 boot. The initramfs SSH-host-keys variant is what exercises the rewritten glob loop.

I also confirmed the gate actually bites rather than passing vacuously — appending `echo $undefined_thing` to the setup helper turns the stage red (exit 1), and removing it turns it green again.

No version bump: 1.2.0 has not been published to the AUR yet, so these fold into it. Checksums and `.SRCINFO` are regenerated for the three changed source files.