### PR TITLE
Retry the headscale download

### DIFF
--- a/tests/04-boot.sh
+++ b/tests/04-boot.sh
@@ -175,7 +175,13 @@ HEADSCALE=${HEADSCALE_BIN:-$WORK/headscale}
 if [[ ! -x $HEADSCALE ]]; then
 	url="https://github.com/juanfont/headscale/releases/download/v${HEADSCALE_VERSION}/headscale_${HEADSCALE_VERSION}_linux_amd64"
 	info "downloading headscale $HEADSCALE_VERSION"
-	curl -fsSL -o "$HEADSCALE" "$url" || die "failed to download $url"
+	# The one thing in this test that depends on somebody else's uptime, and a
+	# single 503 from the release CDN has already failed a run on master.
+	# --retry alone covers the 5xx and timeout cases; --retry-all-errors extends
+	# it to a connection dropped mid-transfer, which is the other way a CDN
+	# fails. The download is checksummed below either way.
+	curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+		-o "$HEADSCALE" "$url" || die "failed to download $url"
 
 	if [[ -n ${HEADSCALE_SHA256:-} ]]; then
 		got=$(sha256sum "$HEADSCALE" | cut -d' ' -f1)


### PR DESCRIPTION
The boot test's one dependency on somebody else's uptime is fetched with a single `curl` and no retry. A 503 from the GitHub release CDN failed [the master run](https://github.com/dangra/mkinitcpio-tailscale/actions/runs/31639176469) right after #8 merged, on a tree that had passed minutes earlier — and the same coin flip decides whether a release tag reaches the AUR, since `publish` needs `boot` green.

```
curl: (22) The requested URL returned error: 503
==> ERROR: failed to download https://github.com/juanfont/headscale/releases/download/v0.26.1/headscale_0.26.1_linux_amd64
```

`--retry 3 --retry-delay 2` covers the 5xx and timeout cases; `--retry-all-errors` extends it to a connection dropped mid-transfer, which is the other way a CDN fails. The download is still verified against the pinned sha256 immediately afterwards, so no retry can smuggle in a truncated or substituted binary.

Verified with `BOOT_SCENARIOS=systemd ./tests/container.sh 04` — downloads, matches the pinned checksum, 17 checks pass.