### PR TITLE
Make the Configure section enough to actually get connected

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,39 +41,88 @@ yay -S mkinitcpio-tailscale
 
 ## Configure
 
-Run the helper and follow the prompts:
+### 1. Register the initrd node
 
 ```sh
 sudo setup-initcpio-tailscale
 ```
 
-This will register a new Tailscale node using a hostname based on your system.
-For example, if your host is named `homeserver`, the node will appear as
-`homeserver-initrd` in the Tailscale admin panel, which makes it easy to
-identify.
+The helper starts a throwaway `tailscaled` and prints a URL and QR code to
+authenticate with; it does not touch the Tailscale service your booted system
+runs. Any extra arguments are passed straight through to `tailscale up`, so
+flags like `--login-server=` work as usual.
 
-Next, edit `/etc/mkinitcpio.conf` and add `tailscale` to the `HOOKS` array.
+It registers a node named after your host with an `-initrd` suffix — a machine
+called `homeserver` appears as `homeserver-initrd` — and leaves its key in
+`/etc/initcpio/tailscale/`.
 
-- For systemd-based initramfs, place the `tailscale` hook anywhere after the
-  `systemd` hook.
-- For busybox-based initramfs, add it after network-related hooks but before
-  blocking hooks like `encrypt` / `encryptssh`.
+**Disable key expiry for that node** in the [machines
+list](https://login.tailscale.com/admin/machines). Node keys expire by default,
+and an expired initrd node cannot reach your tailnet — which you would discover
+while locked out of a machine that is waiting for its passphrase.
 
-Example (conceptual):
+### 2. Give the initramfs a network
+
+Nothing in mkinitcpio's stock hooks brings up networking, and `tailscaled`
+cannot do anything without an address. Add one of these alongside this hook:
+
+| initramfs | hook | package | configured by |
+| --------- | ---- | ------- | ------------- |
+| systemd   | `sd-network` | `mkinitcpio-systemd-extras` (AUR)     | `.network` files copied from `/etc/systemd/network` |
+| busybox   | `net`        | `mkinitcpio-nfs-utils` (official repos) | the `ip=` kernel parameter |
+
+On busybox the ArchWiki's remote-unlock guide reaches for `netconf` instead,
+from [`mkinitcpio-extras`](https://aur.archlinux.org/packages/mkinitcpio-extras);
+that package is worth knowing about if you also want `dropbear` or `tinyssh`, as
+it replaces the unmaintained `mkinitcpio-netconf`, `mkinitcpio-dropbear` and
+`mkinitcpio-tinyssh`. Either hook configures the interface from the same `ip=`
+kernel parameter:
 
 ```text
-HOOKS=(base systemd autodetect modconf block filesystems keyboard fsck tailscale)
-# or for busybox-based initramfs: ensure tailscale is before encrypt
+ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:none
 ```
 
-After editing `mkinitcpio.conf`, regenerate your initramfs:
+Use the kernel's device name (`eth0`) rather than the name the booted system
+shows (`enp1s0`) — the predictable names are not in effect this early. A static
+assignment is the form this project is tested against; `ip=dhcp` leans on the
+hook's own DHCP client, which is a separate thing to get working.
+
+For `sd-network`, match on a glob (`Name=en*`) instead of one fixed name, for
+the same reason.
+
+### 3. Add the hook
+
+Edit `/etc/mkinitcpio.conf` and put `tailscale` after the network hook and
+before whatever blocks waiting for a passphrase — `sd-encrypt`, `encrypt` or
+`encryptssh`:
+
+```text
+# systemd-based
+HOOKS=(base systemd autodetect microcode modconf kms keyboard sd-vconsole block sd-network tailscale sd-encrypt filesystems fsck)
+
+# busybox-based
+HOOKS=(base udev autodetect microcode modconf kms keyboard keymap consolefont block net tailscale encrypt filesystems fsck)
+```
+
+On a systemd-based initramfs `tailscale` **must** come after `systemd`. The hook
+decides which kind of image it is building by looking for helpers that the
+`systemd` hook defines, so listing it earlier silently produces the busybox
+layout — which a systemd initramfs never runs, leaving you with an image that
+builds cleanly and never connects.
+
+### 4. Rebuild and check
 
 ```sh
 sudo mkinitcpio -P
-# or: sudo mkinitcpio -p linux
 ```
 
-This updates your initramfs so the new hook and node key are included.
+Before rebooting a machine you cannot walk up to, confirm the image really
+carries Tailscale and that the node is live:
+
+```sh
+lsinitcpio -l /boot/initramfs-linux.img | grep tailscale
+tailscale status | grep -- -initrd    # from any other node on your tailnet
+```
 
 ### Tailscale SSH server
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,13 @@ a busybox-based initramfs this hook therefore writes a minimal one itself —
 contains. Where a database already exists it is left untouched, so a
 systemd-based image keeps the richer one mkinitcpio built.
 
-That also fixes the same problem for other SSH servers in early userspace: the
-`mkinitcpio-dropbear` and `mkinitcpio-tinyssh` hooks do not ship a user database
-either, and without one both daemons start, accept the connection and then
-refuse every login with `Permission denied (publickey)`. With this hook in
-`HOOKS` they work as expected.
+That also fixes the same problem for other SSH servers in early userspace.
+Without a user database `dropbear` and `tinyssh` start, accept the connection,
+and then refuse every login with `Permission denied (publickey)` — the old
+standalone hooks never wrote one, and the maintained `mkinitcpio-extras` fork
+does so only if you turn its root-shell option on. This hook writes one whenever
+the image has none, so they work either way, and skips it when a database is
+already there, so the two cannot collide.
 
 **Run one SSH server, not two.** When Tailscale SSH is enabled, tailscaled
 answers port 22 on the tailnet itself, so a dropbear or tinyssh in the same

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ while locked out of a machine that is waiting for its passphrase.
 
 ### 2. Give the initramfs a network
 
-Nothing in mkinitcpio's stock hooks brings up networking, and `tailscaled`
+Nothing in mkinitcpio's stock hooks bring up networking, and `tailscaled`
 cannot do anything without an address. Add one of these alongside this hook:
 
 | initramfs | hook | package | configured by |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ while locked out of a machine that is waiting for its passphrase.
 
 ### 2. Give the initramfs a network
 
-Nothing in mkinitcpio's stock hooks bring up networking, and `tailscaled`
+Nothing in mkinitcpio's stock hooks brings up networking, and `tailscaled`
 cannot do anything without an address. Add one of these alongside this hook:
 
 | initramfs | hook | package | configured by |

--- a/README.md
+++ b/README.md
@@ -68,27 +68,30 @@ cannot do anything without an address. Add one of these alongside this hook:
 
 | initramfs | hook | package | configured by |
 | --------- | ---- | ------- | ------------- |
-| systemd   | `sd-network` | `mkinitcpio-systemd-extras` (AUR)     | `.network` files copied from `/etc/systemd/network` |
-| busybox   | `net`        | `mkinitcpio-nfs-utils` (official repos) | the `ip=` kernel parameter |
+| systemd   | `sd-network` | `mkinitcpio-systemd-extras` (AUR)   | `.network` files copied from `/etc/systemd/network` |
+| busybox   | `net`        | `mkinitcpio-nfs-utils` (core)       | the `ip=` kernel parameter |
+| busybox   | `netconf`    | [`mkinitcpio-extras`][extras] (AUR) | the `ip=` kernel parameter |
 
-On busybox the ArchWiki's remote-unlock guide reaches for `netconf` instead,
-from [`mkinitcpio-extras`](https://aur.archlinux.org/packages/mkinitcpio-extras);
-that package is worth knowing about if you also want `dropbear` or `tinyssh`, as
-it replaces the unmaintained `mkinitcpio-netconf`, `mkinitcpio-dropbear` and
-`mkinitcpio-tinyssh`. Either hook configures the interface from the same `ip=`
-kernel parameter:
+Both busybox hooks take the same parameter, and either works with this hook —
+they differ in what they can be told to do and where they come from:
 
 ```text
-ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:none
+ip=192.168.1.50::192.168.1.1:255.255.255.0::eth0:none    # static, both hooks
+ip=dhcp                                                  # netconf
 ```
 
-Use the kernel's device name (`eth0`) rather than the name the booted system
-shows (`enp1s0`) — the predictable names are not in effect this early. A static
-assignment is the form this project is tested against; `ip=dhcp` leans on the
-hook's own DHCP client, which is a separate thing to get working.
+`net` comes from the official repositories and needs no AUR build, which is
+reason enough to prefer it when the machine has a fixed address. Its DHCP client
+did not come up in testing, so reach for `netconf` if you need `ip=dhcp` —
+that is also what the ArchWiki's remote-unlock guide uses, and
+[`mkinitcpio-extras`][extras] is the maintained replacement for the retired
+`mkinitcpio-netconf`, `mkinitcpio-dropbear` and `mkinitcpio-tinyssh`, so it is
+the one to pick if you also want a `dropbear` or `tinyssh` alongside.
 
-For `sd-network`, match on a glob (`Name=en*`) instead of one fixed name, for
-the same reason.
+Use the kernel's device name (`eth0`) rather than the name the booted system
+shows (`enp1s0`) — the predictable names are not in effect this early. For
+`sd-network`, match on a glob (`Name=en*`) instead of one fixed name, for the
+same reason.
 
 ### 3. Add the hook
 
@@ -299,6 +302,7 @@ AUR_REMOTE=/tmp/fake-aur.git ./scripts/aur-publish.sh --tag v1.2.0
 [gh3]: https://github.com/classabbyamp
 [gh4]: https://github.com/wolegis
 [aur]: https://aur.archlinux.org/packages/mkinitcpio-tailscale
+[extras]: https://aur.archlinux.org/packages/mkinitcpio-extras
 [1]: https://wiki.archlinux.org/title/Mkinitcpio
 [2]: https://tailscale.com
 [3]: https://wiki.archlinux.org/title/dm-crypt/Encrypting_an_entire_system#Configuring_mkinitcpio_2


### PR DESCRIPTION
Following the Configure section exactly produced an initramfs that could not work, and it never said so.

**Nothing in mkinitcpio's stock hooks brings up networking.** `tailscaled` would start with no address, the machine would never appear on the tailnet, and nothing in the section hinted at what was missing. The install hook's own `help()` has been saying "remember to also configure network and a ssh server hooks" all along — the README was behind its own hook.

**The example `HOOKS` line argued against the advice above it:**

```text
HOOKS=(base systemd autodetect modconf block filesystems keyboard fsck tailscale)
```

No network hook, no encrypt hook of any kind, and `tailscale` last — after `filesystems` and `fsck` — which is exactly where the busybox bullet two lines earlier says not to put it.

**"Anywhere after the `systemd` hook" understated its own footgun.** `add_systemd_unit` is defined *inside* `/usr/lib/initcpio/install/systemd` and mkinitcpio sources install hooks in `HOOKS` order, so listing `tailscale` earlier makes `build()` take the busybox branch and install a runscript a systemd initramfs never executes. It builds cleanly and never connects.

## Now four steps, with the prerequisites in them

Register the node → give the initramfs a network → add the hook → rebuild and check. Also folded in: disabling key expiry (the helper says it once, the README never repeated it — an expired initrd key is discovered while locked out), the fact that the helper prints a URL and QR rather than prompting, and a way to verify the image *before* rebooting a machine nobody can walk up to.

## Network hook guidance is measured, not guessed

I booted each hook against this one, on the same QEMU setup the test suite uses:

| hook | package | repo | static `ip=` | `ip=dhcp` |
| --- | --- | --- | --- | --- |
| `net` | `mkinitcpio-nfs-utils` | core | online in 5s | ipconfig loops on `SIOCGIFFLAGS`, boot never reaches tailscaled |
| `netconf` | `mkinitcpio-extras` | AUR | same parser | `complete (dhcp from 10.0.2.2)`, online in 5s |

So the README recommends `net` from core when the machine has a fixed address — no AUR build — and `netconf` when you need DHCP or also want a busybox `dropbear`/`tinyssh`. `mkinitcpio-extras` is the maintained replacement for the retired `mkinitcpio-netconf`, `mkinitcpio-dropbear` and `mkinitcpio-tinyssh`; the ArchWiki dropped those as unmaintained, and my first draft cited one of them.

## One correction to a claim I made in #8

I had written that the dropbear and tinyssh hooks ship no user database. True of the two packages I booted — **not** true of `mkinitcpio-extras`, whose hooks write the same three lines this hook does (`root:x:0:0:root:/root:/bin/sh`, `root:*:::::::`, `root:x:0:`), though only when their root-shell option is set. Independent convergence on the same fix, which is reassuring; the wording is precise now.

No code changes — README only.
