### PR TITLE
Enable Tailscale SSH by default, with --no-ssh to opt out

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ narrowed to the initrd device alone — see [Security
 considerations](#security-considerations), which also covers the trade-off of
 keeping a node key in an unencrypted initramfs.
 
-Tailscale's built-in SSH server works here as well, so no separate `dropbear` or
-`tinyssh` is needed — see [Tailscale SSH server](#tailscale-ssh-server). Both
+Tailscale's built-in SSH server is enabled by default, so no separate `dropbear`
+or `tinyssh` is needed — see [Tailscale SSH server](#tailscale-ssh-server). Both
 systemd- and busybox-based initramfs images are supported.
 
 Unlocking the root filesystem is configured separately; the ArchWiki covers that
@@ -53,8 +53,10 @@ runs. Any extra arguments are passed straight through to `tailscale up`, so
 flags like `--login-server=` work as usual.
 
 It registers a node named after your host with an `-initrd` suffix — a machine
-called `homeserver` appears as `homeserver-initrd` — and leaves its key in
-`/etc/initcpio/tailscale/`.
+called `homeserver` appears as `homeserver-initrd` — with [Tailscale
+SSH](#tailscale-ssh-server) turned on, and leaves the node key and the SSH host
+keys in `/etc/initcpio/tailscale/`. Pass `--no-ssh` if you would rather run
+`dropbear` or `tinyssh` in the image instead.
 
 **Disable key expiry for that node** in the [machines
 list](https://login.tailscale.com/admin/machines). Node keys expire by default,
@@ -129,24 +131,31 @@ tailscale status | grep -- -initrd    # from any other node on your tailnet
 
 ### Tailscale SSH server
 
-Tailscale includes a built-in SSH server. If you enable it when running the
-setup helper, you don't need `dropbear`, `tinyssh`, or another SSH server inside
-initramfs.
-
-Enable it with:
+Tailscale includes a built-in SSH server, and `setup-initcpio-tailscale` turns it
+on unless told otherwise, so you need no `dropbear`, `tinyssh`, or other SSH
+server inside the initramfs. Logging in is then:
 
 ```sh
-sudo setup-initcpio-tailscale --ssh
+ssh root@homeserver-initrd
 ```
+
+Turn it off with:
+
+```sh
+sudo setup-initcpio-tailscale --no-ssh
+```
+
+which also removes any host keys an earlier run left in
+`/etc/initcpio/tailscale/`, so they stop being copied into new images.
 
 Note: the Tailscale SSH server only accepts connections from within your
 tailnet. The node won’t accept local connections unless the client is also part
 of your Tailscale network — this reduces exposure compared to a traditional SSH
 server reachable from everywhere.
 
-`setup-initcpio-tailscale --ssh` also generates OpenSSH host keys and stores them
-alongside the node key, so the initramfs presents the same host key every time
-and your client does not warn about a changed identity.
+The helper also generates OpenSSH host keys and stores them alongside the node
+key, so the initramfs presents the same host key every time and your client does
+not warn about a changed identity.
 
 Works on systemd- and busybox-based initramfs alike, though the second needs a
 hand: Tailscale's SSH server has to resolve the user you log in as, and of the
@@ -167,8 +176,8 @@ already there, so the two cannot collide.
 **Run one SSH server, not two.** When Tailscale SSH is enabled, tailscaled
 answers port 22 on the tailnet itself, so a dropbear or tinyssh in the same
 initramfs never sees those connections — it still answers on other interfaces,
-but not on the address you would actually reach it at. Either register with
-`--ssh` and use Tailscale SSH, or leave `--ssh` off and use your own daemon.
+but not on the address you would actually reach it at. Either keep the default
+and use Tailscale SSH, or register with `--no-ssh` and use your own daemon.
 
 The test suite covers this end to end on both branches: it boots the image, logs
 in over Tailscale SSH from a second node on a throwaway tailnet, and checks the
@@ -234,9 +243,11 @@ make test-all    # adds the QEMU boot tests against a local headscale
 ```
 
 `make test-all` boots two images against a throwaway headscale — one systemd,
-one busybox, both registered with `--ssh` — and checks each node comes online,
-then logs in over Tailscale SSH and compares the host key it is offered with the
-one `setup-initcpio-tailscale` generated. A single scenario can be run on its
+one busybox, both registered the way the setup helper registers them when left
+alone — and checks each node comes online, then logs in over Tailscale SSH and
+compares the host key it is offered with the one `setup-initcpio-tailscale`
+generated. The `--no-ssh` opt-out is checked there too, on the configuration it
+writes rather than with a boot of its own. A single scenario can be run on its
 own:
 
 ```sh

--- a/initcpio-install-tailscale
+++ b/initcpio-install-tailscale
@@ -82,7 +82,9 @@ help() {
 
 			* /etc/initcpio/tailscale/default.env to /etc/default/tailscaled
 
-		It works with both, systemd and busybox init systems; whatever you choose remember to also configure network and a ssh server hooks.
+		It works with both, systemd and busybox init systems; whatever you choose remember to also configure a network hook -- nothing in mkinitcpio's stock hooks brings up an interface, and tailscaled cannot do anything without an address.
+
+		A ssh server hook is not needed: setup-initcpio-tailscale enables Tailscale's own SSH server unless it was run with '--no-ssh'.
 
 		For systemd init, see 'sd-network' and 'sd-tinyssh' hooks provided by mkinitcpio-systemd-extras package.
 

--- a/setup-initcpio-tailscale
+++ b/setup-initcpio-tailscale
@@ -15,11 +15,22 @@ usage: ${CMD0} [option...]
 The setup script shouldn't require any arguments to get it working, but keep in mind that any extra argument is passed as-is to 'tailscale up'.
 See 'tailscale up --help' for available flags.
 
+Defaults:
+
+  --hostname    the current hostname plus an '-initrd' suffix, in this case "${TS_HOSTNAME}".
+
+  --ssh         Tailscale's built-in SSH server is enabled, so the initramfs is
+                reachable without a second ssh server in it. OpenSSH host keys
+                are generated alongside the node key so the image presents the
+                same identity on every boot.
+
+  --no-ssh      Turns that off, for images that run their own dropbear or
+                tinyssh instead. Only one of them can answer port 22 on the
+                tailnet, so don't enable both.
+
 i.e.:
 
-  ${CMD0} --hostname ${TS_HOSTNAME} --ssh --login-server=headscale.my.net --authkey=file:node.key
-
-The default value for '--hostname' is the current hostname plus '-initrd' suffix, in this case "${TS_HOSTNAME}".
+  ${CMD0} --hostname ${TS_HOSTNAME} --login-server=headscale.my.net --authkey=file:node.key
 
 If in doubt, run '$CMD0' without arguments.
 EOF
@@ -33,40 +44,93 @@ die() {
 }
 
 cleanup() {
-  if [[ -n "${SETUPDIR}" ]]; then
+  # Whatever brought us here, on the way out. Exiting 0 unconditionally, as this
+  # used to, reported every failure -- die() included -- as a successful setup.
+  local rc=$?
+  if [[ -n "${SETUPDIR:-}" ]]; then
     rm -rf "${SETUPDIR}"
   fi
   if [[ -n "$PID" ]]; then
-    kill "$PID" 2>/dev/null
+    kill "$PID" 2>/dev/null || true
   fi
-  exit 0
+  exit "$rc"
 }
 trap "cleanup" EXIT
 
-# Scan arguments looking for --hostname=VALUE
+# Scan the arguments for the two flags this script has an opinion about, and
+# note whether the user stated them so the defaults below only fill in gaps.
+#
+# Tailscale SSH is on unless asked otherwise: an initrd node exists to be logged
+# into, and enabling it here is what saves the image from needing a dropbear or
+# tinyssh of its own. '--no-ssh' is this script's own spelling -- 'tailscale up'
+# has no such flag -- so it is dropped from the arguments rather than passed on.
+TS_SSH=yes
 FOUND_HOSTNAME_IN_ARGS=no
 FOUND_SSH_IN_ARGS=no
+TS_ARGS=()
+WANT_HOSTNAME=no
+
 for arg in "$@"; do
-  if [[ $arg =~ ^(-h|--help|help)$ ]]; then
+  if [[ $WANT_HOSTNAME == yes ]]; then
+    # The value half of a space separated '--hostname NAME'.
+    WANT_HOSTNAME=no
+    TS_HOSTNAME=${arg//[\"\']/}
+    TS_ARGS+=("$arg")
+    continue
+  fi
+
+  # Matching is done with the leading dashes stripped: 'tailscale up' is a Go
+  # flag parser and takes '-ssh' and '--ssh' alike, so this script does too.
+  flag=${arg#-}
+  flag=${flag#-}
+
+  case $flag in
+  h | help)
     usage
     exit 0
-  fi
-  if [[ $arg =~ ^--hostname= ]]; then
-    TS_HOSTNAME=${arg#*=}
+    ;;
+  hostname)
+    FOUND_HOSTNAME_IN_ARGS=yes
+    WANT_HOSTNAME=yes
+    ;;
+  hostname=*)
+    TS_HOSTNAME=${flag#*=}
     TS_HOSTNAME=${TS_HOSTNAME//[\"\']/}
     FOUND_HOSTNAME_IN_ARGS=yes
-  fi
-  if [[ $arg =~ ^--ssh$ ]]; then
+    ;;
+  no-ssh)
+    TS_SSH=no
     FOUND_SSH_IN_ARGS=yes
-  fi
+    continue
+    ;;
+  ssh | ssh=*)
+    FOUND_SSH_IN_ARGS=yes
+    # The spellings Go's flag package accepts for a boolean.
+    case ${flag#ssh} in
+    '' | =1 | =t | =T | =true | =TRUE | =True) TS_SSH=yes ;;
+    *) TS_SSH=no ;;
+    esac
+    ;;
+  esac
+  TS_ARGS+=("$arg")
 done
+[[ $WANT_HOSTNAME == no ]] || die "--hostname needs a value"
+
+# Defaults are prepended, so an argument the user did pass always has the last
+# word with the flag parser on the other end.
+set -- "${TS_ARGS[@]}"
+[[ $FOUND_SSH_IN_ARGS == yes ]] || set -- --ssh "$@"
 [[ $FOUND_HOSTNAME_IN_ARGS == yes ]] || set -- --hostname="$TS_HOSTNAME" "$@"
 
 SETUPDIR="$(mktemp -d)"
 socket="${SETUPDIR}/tailscaled.sock"
 state="${SETUPDIR}/tailscaled.state"
 
-if [[ $FOUND_SSH_IN_ARGS == yes ]]; then
+if [[ $TS_SSH == yes ]]; then
+  # ssh-keygen -A writes into <prefix>/etc/ssh and will not create the directory
+  # itself. The keys are the initrd node's stable identity: generating them here,
+  # rather than letting the image make new ones on each boot, is what keeps a
+  # client from warning about a changed host key every time the machine reboots.
   mkdir -p "${SETUPDIR}/etc/ssh"
   ssh-keygen -A -f "${SETUPDIR}"
 fi
@@ -100,9 +164,17 @@ PORT="41641"
 FLAGS=""
 EOF
 
-if [[ -d "${SETUPDIR}/etc/ssh" ]]; then
+if [[ $TS_SSH == yes ]]; then
   $xsu install -o root -g root -m600 -Dt "${TS_STATEDIR}/ssh" "${SETUPDIR}/etc/ssh/"ssh_host_*_key
   $xsu install -o root -g root -m644 -Dt "${TS_STATEDIR}/ssh" "${SETUPDIR}/etc/ssh/"ssh_host_*_key.pub
+  ssh_note="  * Tailscale SSH is enabled, so you will log in with 'ssh root@${TS_HOSTNAME}'
+    and need no ssh server hook in the image. Re-run with '--no-ssh' to use your own"
+else
+  # Host keys left behind by an earlier run would otherwise be copied into every
+  # image built from here on, for an SSH server this node no longer runs.
+  $xsu rm -rf "${TS_STATEDIR}/ssh"
+  ssh_note="  * Tailscale SSH is disabled, so add an ssh server hook (dropbear or tinyssh)
+    to /etc/mkinitcpio.conf or you will have no way to enter the passphrase"
 fi
 
 info "tailscale successfully configured.
@@ -111,6 +183,8 @@ Next steps:
   * Disable key expiry for '${TS_HOSTNAME}' at https://login.tailscale.com/admin/machines
   * Review ${TS_STATEDIR}/default.env (as root)
   * Edit /etc/mkinitcpio.conf and add 'tailscale'. A safe choice is to insert it right before 'sd-encrypt' or 'encrypt*' hooks
+  * Add a network hook too -- 'sd-network' on a systemd image, 'net' or 'netconf' on a busybox one -- since nothing in mkinitcpio's stock hooks brings up an interface
+${ssh_note}
   * Run 'mkinitcpio -P' to rebuild initramfs
   * Check the README at https://github.com/dangra/mkinitcpio-tailscale for security considerations
 

--- a/tests/04-boot.sh
+++ b/tests/04-boot.sh
@@ -11,7 +11,7 @@
 # state copied into the image -> tailscaled started inside the initramfs ->
 # network up -> node reachable on the tailnet -> reachable *as the same host*
 # a client already knows. It also gives setup-initcpio-tailscale its only
-# coverage, via the non-interactive --authkey --ssh path.
+# coverage, via the non-interactive --authkey path.
 #
 # One boot per branch of the install hook, since the two produce genuinely
 # different images and the runtime hook only runs in the second:
@@ -19,8 +19,10 @@
 #   systemd   HOOKS=(base systemd ... tailscale)   tailscaled.service
 #   busybox   HOOKS=(base udev ... tailscale)      initcpio-hooks-tailscale
 #
-# Both register with --ssh: that state is a superset of the plain one, so two
-# boots cover both branches and the ssh path. The images also carry the two
+# Both register with Tailscale SSH, which is what the setup helper does when
+# left alone: that state is a superset of the plain one, so two boots cover both
+# branches and the ssh path. The --no-ssh side is asserted on the configuration
+# the helper writes, without a boot of its own. The images also carry the two
 # test-only hooks under tests/initcpio -- testnet for an address on QEMU's
 # user-mode network, testuser for the login the ssh assertions use.
 #
@@ -323,12 +325,13 @@ group 'setup-initcpio-tailscale against headscale'
 for sc in "${SCENARIOS[@]}"; do
 	node="${TS_NODE_NAME}-${SC_SUFFIX[$sc]}"
 
+	# No --ssh: Tailscale SSH is the default, and the host key assertions further
+	# down are what proves the default took effect.
 	rm -rf "$TS_SETUPDIR"
 	if "$SETUP_HELPER" \
 		--hostname="$node" \
 		--login-server="$SERVER_URL" \
-		--authkey="$AUTHKEY" \
-		--ssh >"$WORK/setup.$sc.log" 2>&1; then
+		--authkey="$AUTHKEY" >"$WORK/setup.$sc.log" 2>&1; then
 		pass "$sc: setup-initcpio-tailscale registers $node"
 	else
 		fail "$sc: setup-initcpio-tailscale registers $node" "$(cat "$WORK/setup.$sc.log")"
@@ -348,6 +351,29 @@ for sc in "${SCENARIOS[@]}"; do
 	# back immediately before the image that needs it is built.
 	cp -a "$TS_SETUPDIR" "$WORK/state.$sc"
 done
+endgroup
+
+# --- the opt-out ----------------------------------------------------------
+# Deliberately run over the directory the loop above left behind, host keys and
+# all: --no-ssh has to clear them, or every image built afterwards would still
+# carry keys for an ssh server this node no longer runs.
+group 'setup-initcpio-tailscale --no-ssh'
+check 'the previous run left host keys behind' test -d "$TS_SETUPDIR/ssh"
+if "$SETUP_HELPER" \
+	--hostname="${TS_NODE_NAME}-nossh" \
+	--login-server="$SERVER_URL" \
+	--authkey="$AUTHKEY" \
+	--no-ssh >"$WORK/setup.nossh.log" 2>&1; then
+	pass '--no-ssh registers the node'
+else
+	fail '--no-ssh registers the node' "$(cat "$WORK/setup.nossh.log")"
+fi
+check '--no-ssh still wrote tailscaled.state' test -s "$TS_SETUPDIR/tailscaled.state"
+check_fails '--no-ssh leaves no host keys behind' test -e "$TS_SETUPDIR/ssh"
+# 'tailscale up' has no --no-ssh flag, so a pass-through would have failed the
+# registration above with "flag provided but not defined".
+check_fails '--no-ssh never reached tailscale up' \
+	grep -q 'not defined' "$WORK/setup.nossh.log"
 endgroup
 
 # --- a client on the tailnet ----------------------------------------------


### PR DESCRIPTION
Registering an initrd node and then finding it unreachable is the wrong default: the node exists to be logged into. `setup-initcpio-tailscale` now enables Tailscale's built-in SSH server unless told otherwise, and generates the OpenSSH host keys that give the image a stable identity across reboots.

## Opting out

`--no-ssh` turns it off, for images that run `dropbear` or `tinyssh` instead. It also removes any host keys an earlier run left in `/etc/initcpio/tailscale/ssh`, which would otherwise keep being copied into every image built afterwards, for a server the node no longer runs.

`--no-ssh` is this script's own spelling — `tailscale up` has no such flag — so it is consumed rather than passed through. The scan that decides this also learned the other spellings the flag parser on the other end accepts: `-ssh`, `--ssh=false`, `--ssh=0`, and a space-separated `--hostname NAME`, which the old `^--hostname=` match missed. A flag you pass explicitly still wins; the defaults only fill gaps.

## Bug fixed along the way

The `EXIT` trap ended with `exit 0`, so the helper reported success for every failure, `die` included — a failed `tailscale up` looked like a completed setup, and the boot test's `if "$SETUP_HELPER" ...` could never have caught it. It now preserves the status it was called with.

## Also

The next-steps output names the network hook (`sd-network` / `net` / `netconf`), since nothing in mkinitcpio's stock hooks brings up an interface and its absence otherwise surfaces as an image that builds cleanly and never connects. It then tells you either how to log in (`ssh root@<host>-initrd`) or, under `--no-ssh`, that you now need an ssh server hook of your own.

## Tests

`tests/04-boot.sh` registers both scenarios without `--ssh`, so its existing host-key assertions are what prove the default took effect. A new group runs `--no-ssh` deliberately over the host keys the previous scenario left behind and checks they are cleared, that the state file is still written, and that the flag never reached `tailscale up`.

All four stages pass locally, including both QEMU boots logging in over Tailscale SSH with no `--ssh` flag anywhere:

```
01-lint        24 checks passed
02-package     22 checks passed
03-initramfs  110 checks passed
04-boot        34 checks passed
```