### PR TITLE
Run on Void Linux: portable hook, Void test lane, research report

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,56 @@ jobs:
           path: logs/
           if-no-files-found: ignore
 
+  initramfs-void:
+    name: initramfs (void)
+    runs-on: ubuntu-latest
+    container: ghcr.io/void-linux/void-glibc:latest
+    timeout-minutes: 30
+    steps:
+      # The same static checks and image builds as the two jobs above, on the
+      # other distro that runs this hook: Void's mkinitcpio, no systemd, so
+      # tests/03-initramfs.sh exercises its busybox variants only. Keep the
+      # bootstrap in step with the void lane of tests/container.sh.
+      - name: Bootstrap
+        run: |
+          # The container image slims itself with noextract rules that also
+          # strip files mkinitcpio needs at image build time, the udev
+          # helpers among them. Drop the rules before anything installs, and
+          # reinstall the two packages whose payloads the image was built
+          # without, so the container looks like a real Void system where it
+          # matters. findutils, diffutils and kbd likewise: mkinitcpio builds
+          # images with find, the keymap and consolefont hooks run loadkeys
+          # and setfont, and the tests byte-compare with cmp and diff.
+          rm -f /etc/xbps.d/noextract*.conf
+          xbps-install -Syu xbps
+          xbps-install -yu
+          # git has to be installed before actions/checkout, otherwise it
+          # falls back to downloading a REST tarball; libstdc++ is for the
+          # runner's node, which actions run on.
+          xbps-install -y git bash libstdc++ findutils diffutils kbd shellcheck mkinitcpio tailscale openssh
+          xbps-install -yf eudev libkmod
+          # Installing a kernel runs the /etc/kernel.d hooks, and mkinitcpio's
+          # would build an initramfs against the stock preset, which cannot
+          # work in a container. A /dev/null symlink is not executable, so the
+          # kernel trigger skips it; the tests build their images with their
+          # own configuration.
+          ln -sf /dev/null /etc/kernel.d/post-install/20-initramfs
+          xbps-install -y linux
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Static checks and image contents with Void's mkinitcpio
+        run: ./tests/run.sh 01 03
+        env:
+          ARTIFACT_DIR: ${{ github.workspace }}/logs
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: failure()
+        with:
+          name: initramfs-void-logs
+          path: logs/
+          if-no-files-found: ignore
+
   boot:
     name: boot
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 STAGEDIR ?= .stage
 TAG ?=
 
-.PHONY: stage build install publish test test-all clean
+.PHONY: stage build install publish test test-all test-void clean
 
 
 # PKGBUILD in this repo is a template: pkgver, pkgrel and sha256sums are
@@ -33,6 +33,11 @@ test:
 # Adds the QEMU boot test against a throwaway headscale server.
 test-all:
 	./tests/container.sh all
+
+# The lint and image-contents stages again, in a throwaway Void Linux
+# container: no systemd, Void's mkinitcpio. See docs/void-port.md.
+test-void:
+	./tests/container.sh void
 
 clean:
 	rm -rf "$(STAGEDIR)"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -20,7 +20,7 @@ arch=("any")
 url="https://github.com/dangra/mkinitcpio-tailscale"
 license=("GPL-2.0-or-later")
 # tailscale is needed at image build time: the install hook refuses to build
-# without the package installed.
+# without tailscaled present.
 depends=("mkinitcpio" "tailscale")
 optdepends=("openssh: host key generation for the default Tailscale SSH setup"
   "jq: node key expiry checking in setup-initcpio-tailscale --check")

--- a/README.md
+++ b/README.md
@@ -277,6 +277,16 @@ example below is valid headscale policy. This is not a theoretical
 combination: the test suite boots every scenario against a throwaway
 headscale, so the path you are on is the one CI exercises.
 
+## Void Linux
+
+Only the packaging here is Arch's: the hook itself is distro-neutral, and Void
+supports mkinitcpio as a first-class alternative to dracut, so this project
+runs there too, busybox images only since Void has no systemd. Void's own
+repos also carry a leaner hook under the same name. What transfers, what
+does not, and how to install by hand is covered in
+[docs/void-port.md](docs/void-port.md); CI builds and inspects images with
+Void's mkinitcpio on every change.
+
 ## Security considerations
 
 The Tailscale node key is stored in plaintext inside the initramfs. Initramfs is

--- a/contrib/void/template
+++ b/contrib/void/template
@@ -1,0 +1,38 @@
+# Template file for 'initcpio-tailscale'
+#
+# The upstream project is named mkinitcpio-tailscale, but Void's official
+# repos already carry a different, leaner hook under that name (classabbyamp's,
+# credited in the README as prior work), so this template takes the name this
+# repo's own files carry: initcpio-tailscale, as in setup-initcpio-tailscale
+# and initcpio-hooks-tailscale.
+#
+# It is offered for building locally with xbps-src, not submitted to
+# void-packages; see docs/void-port.md for the coexist stance. To build, copy
+# this directory to srcpkgs/initcpio-tailscale in a void-packages checkout and
+# run ./xbps-src pkg initcpio-tailscale.
+#
+# openssh (ssh-keygen) is needed by the default setup path, which generates
+# SSH host keys for Tailscale SSH, and jq by the key-expiry probe of
+# setup-initcpio-tailscale --check; both fail cleanly with instructions when
+# absent, so neither is a hard dependency. XBPS has no transaction hooks, so
+# unlike the Arch package nothing rebuilds the initramfs when tailscale is
+# upgraded: run mkinitcpio -P yourself afterwards.
+pkgname=initcpio-tailscale
+version=2.5.0
+revision=1
+depends="mkinitcpio tailscale"
+short_desc="Tailscale in the initramfs, with setup helper and Tailscale SSH"
+maintainer="Daniel Graña <dangra@gmail.com>"
+license="GPL-2.0-or-later"
+homepage="https://github.com/dangra/mkinitcpio-tailscale"
+distfiles="https://github.com/dangra/mkinitcpio-tailscale/archive/refs/tags/v${version}.tar.gz"
+checksum=96b9fc3aa5504fab5aa7365f06d30fee2783278456ffefeb8e1387c12800cffe
+# Both packages install /usr/lib/initcpio/{install,hooks}/tailscale: the hook
+# is named 'tailscale' in HOOKS= either way, so only one can be present.
+conflicts="mkinitcpio-tailscale>=0"
+
+do_install() {
+	vinstall initcpio-install-tailscale 644 usr/lib/initcpio/install tailscale
+	vinstall initcpio-hooks-tailscale 644 usr/lib/initcpio/hooks tailscale
+	vbin setup-initcpio-tailscale
+}

--- a/docs/void-port.md
+++ b/docs/void-port.md
@@ -1,9 +1,11 @@
 # Reusing this hook on Void Linux
 
-Research notes on what it would take to run mkinitcpio-tailscale on Void Linux.
-This is a report, not a commitment: nothing in the repo changes with it, and the
-gaps it lists are the work a port would consist of. Facts were checked against
-the Void handbook, the void-packages templates and a live mirror on 2026-08-18.
+Research notes on what it takes to run mkinitcpio-tailscale on Void Linux,
+and what of that has landed. The hook and setup helper now run unchanged on
+Void, and CI proves it: the `initramfs (void)` job and `make test-void` build
+and inspect images with Void's mkinitcpio on a host with no systemd. What
+remains open is listed below. Facts were checked against the Void handbook,
+the void-packages templates and a live mirror on 2026-08-18.
 
 ## Why Void is a natural target
 
@@ -38,10 +40,13 @@ detection (`add_systemd_unit` never exists on Void), so the systemd branch is
 dead code rather than a porting problem, and the busybox branch is the one the
 QEMU boot matrix already exercises.
 
-## What already works unchanged
+## What works unchanged
 
-Most of the codebase is distro-neutral today:
+Most of the codebase is distro-neutral:
 
+- **The install hook** requires only that `tailscaled` be on PATH; it asks no
+  package manager anything. (`add_binary` would fail the build anyway; the
+  guard exists for the friendlier message.)
 - **The runtime hook** is busybox ash against mkinitcpio's own init; nothing in
   it is Arch's.
 - **The install hook's hardcoded `/usr/sbin/tailscaled`** resolves on Void even
@@ -58,9 +63,9 @@ Most of the codebase is distro-neutral today:
 - **The configuration paths** under `/etc/initcpio/tailscale/` carry no distro
   assumption.
 
-## The gap list
+## What stays Arch-only
 
-What a port would actually touch, in decreasing order of substance:
+The pieces with no Void counterpart, in decreasing order of substance:
 
 1. **Rebuild on tailscale upgrades.** The libalpm hook and script pair has no
    XBPS equivalent: XBPS has no user-definable transaction hooks, so a package
@@ -68,17 +73,12 @@ What a port would actually touch, in decreasing order of substance:
    documentation: after a `tailscale` upgrade, run `mkinitcpio -P` (or
    `xbps-reconfigure -f linux<x>.<y>`) by hand, or the image keeps booting the
    old daemon. This is the one functional gap.
-2. **The `pacman -Qi tailscale` guard** in the install hook is likely not
-   needed at all: `add_binary` already fails the build when `tailscaled` is
-   absent, so the guard only buys a friendlier message, and
-   `command -v tailscaled` buys the same one without asking any package
-   manager. Deletion or that one-line swap makes the hook portable.
-3. **The alpm scriptlet** (`mkinitcpio-tailscale.install`, the 2.0.0 TUN
+2. **The alpm scriptlet** (`mkinitcpio-tailscale.install`, the 2.0.0 TUN
    migration) is irrelevant to a fresh Void install and needs no counterpart.
-4. **The PKGBUILD and AUR pipeline** are Arch-only by nature and stay that way;
+3. **The PKGBUILD and AUR pipeline** are Arch-only by nature and stay that way;
    see the next section for why no Void package is planned.
-5. **Docs text.** The README's install and next-steps guidance assumes pacman
-   and the AUR, and its systemd rows do not apply on Void.
+4. **The README's install guidance** assumes pacman and the AUR, and its
+   systemd rows do not apply on Void; its Void section points back here.
 
 ## The existing Void package
 
@@ -97,10 +97,9 @@ netfilter in the image, persisted Tailscale SSH host identity) can install it
 from git; users who want an `xbps-install` one-liner already have one. A
 void-packages submission under a colliding name is not on the table.
 
-## Manual install sketch
+## Manual install
 
-What a Void user would do today, once the gap-list items land. File
-destinations mirror the PKGBUILD's:
+What a Void user does today:
 
 ```sh
 xbps-install mkinitcpio mkinitcpio-encrypt mkinitcpio-nfs-utils tailscale
@@ -119,19 +118,16 @@ before `encrypt` in `HOOKS=`, rebuild with `mkinitcpio -P`, and verify with
 `setup-initcpio-tailscale --check`. The one Void-specific habit is rebuilding
 by hand after a `tailscale` upgrade, since no hook does it for you.
 
-## Validation plan
+## Validation
 
-When the port happens, in this order:
-
-1. **A Void container lane** beside the Arch one in `tests/container.sh`:
-   run the lint, packaging and image-contents scripts (tests/01 to 03) in
-   `ghcr.io/void-linux/void-glibc`, installing `mkinitcpio` and `tailscale`
-   via xbps and copying the hook files into place by hand, since there is no
-   package to install. Building the image with Void's mkinitcpio 41 and
-   inspecting it for `tailscaled`, the passwd database and the tun-module
-   logic covers most of what the port could break.
-2. **A Void QEMU boot scenario** against the throwaway headscale, later. The
-   boot matrix stays Arch-only until the container lane exists and is green.
+1. **The Void container lane** exists: `make test-void` (or
+   `tests/container.sh void`) runs the lint and image-contents stages in
+   `ghcr.io/void-linux/void-glibc`, and CI runs the same as the
+   `initramfs (void)` job on every change. Images are built with Void's
+   mkinitcpio on a host with no systemd, so the suite exercises exactly the
+   busybox variants a Void machine would boot, and skips the systemd ones.
+2. **A Void QEMU boot scenario** against the throwaway headscale remains
+   future work; the boot matrix stays Arch-only until someone takes it on.
 
 [void-mkinitcpio]: https://github.com/void-linux/void-packages/blob/master/srcpkgs/mkinitcpio/template
 [void-kernel]: https://docs.voidlinux.org/config/kernel.html

--- a/docs/void-port.md
+++ b/docs/void-port.md
@@ -97,6 +97,14 @@ netfilter in the image, persisted Tailscale SSH host identity) can install it
 from git; users who want an `xbps-install` one-liner already have one. A
 void-packages submission under a colliding name is not on the table.
 
+For building a proper XBPS package locally all the same, the repo carries an
+xbps-src template at [contrib/void/template](../contrib/void/template) under
+the name `initcpio-tailscale`, the name this repo's own files already carry.
+It marks `conflicts` with the official package, since both install the
+`tailscale` hook under `/usr/lib/initcpio`, and it is not submitted anywhere:
+copy it to `srcpkgs/initcpio-tailscale` in a void-packages checkout and run
+`./xbps-src pkg initcpio-tailscale`.
+
 ## Manual install
 
 What a Void user does today:

--- a/docs/void-port.md
+++ b/docs/void-port.md
@@ -1,0 +1,140 @@
+# Reusing this hook on Void Linux
+
+Research notes on what it would take to run mkinitcpio-tailscale on Void Linux.
+This is a report, not a commitment: nothing in the repo changes with it, and the
+gaps it lists are the work a port would consist of. Facts were checked against
+the Void handbook, the void-packages templates and a live mirror on 2026-08-18.
+
+## Why Void is a natural target
+
+Void supports mkinitcpio as a first-class alternative to dracut, its default
+initramfs generator. The [mkinitcpio package][void-mkinitcpio] (version 41, the
+same generation Arch ships) registers in the XBPS `initramfs` alternatives
+group; switching a machine over is:
+
+```sh
+xbps-install mkinitcpio
+xbps-alternatives -s mkinitcpio
+xbps-reconfigure -f linux<x>.<y>   # per installed kernel
+```
+
+as the [Void handbook][void-kernel] describes. From then on kernel updates
+rebuild the image through Void's `/etc/kernel.d` hooks, which the alternatives
+group points at mkinitcpio's own kernel hook. The supporting hooks this README
+recommends are all in Void's official repos, in some cases more conveniently
+than on Arch, where `netconf` lives in the AUR:
+
+| package | version | provides |
+| ------- | ------- | -------- |
+| `mkinitcpio-nfs-utils` | 0.3 | the `net` hook |
+| `mkinitcpio-netconf` | 0.0.5 | the `netconf` hook |
+| `mkinitcpio-dropbear` | 0.0.5 | the `dropbear` hook |
+| `mkinitcpio-encrypt` | 41 | the `encrypt` hook, split out of base mkinitcpio |
+| `tailscale` | 1.102.2 | `tailscaled` and the CLI, in `/usr/bin` |
+
+Void has no systemd, so only the busybox half of this project would ever run
+there. That costs nothing: the install hook picks its layout by feature
+detection (`add_systemd_unit` never exists on Void), so the systemd branch is
+dead code rather than a porting problem, and the busybox branch is the one the
+QEMU boot matrix already exercises.
+
+## What already works unchanged
+
+Most of the codebase is distro-neutral today:
+
+- **The runtime hook** is busybox ash against mkinitcpio's own init; nothing in
+  it is Arch's.
+- **The install hook's hardcoded `/usr/sbin/tailscaled`** resolves on Void even
+  though its tailscale package installs to `/usr/bin`: mkinitcpio's
+  `initialize_buildroot` creates `usr/sbin -> bin` inside every image, and
+  `add_binary tailscaled` resolves through PATH on the host.
+- **`getent`** exists on both Void libcs: glibc ships it, and Void's
+  [musl package][void-musl] builds one of its own. tailscaled itself is Go and
+  runs fine on musl.
+- **`setup-initcpio-tailscale`** needs bash, sudo or doas, ssh-keygen, and
+  optionally jq, all ordinary Void packages. Its `--check` parses the same
+  `/etc/mkinitcpio.conf`, uses the same `lsinitcpio`, and inspects the same
+  `/boot/initramfs-*.img` naming.
+- **The configuration paths** under `/etc/initcpio/tailscale/` carry no distro
+  assumption.
+
+## The gap list
+
+What a port would actually touch, in decreasing order of substance:
+
+1. **Rebuild on tailscale upgrades.** The libalpm hook and script pair has no
+   XBPS equivalent: XBPS has no user-definable transaction hooks, so a package
+   cannot react to another package's upgrade. On Void this becomes
+   documentation: after a `tailscale` upgrade, run `mkinitcpio -P` (or
+   `xbps-reconfigure -f linux<x>.<y>`) by hand, or the image keeps booting the
+   old daemon. This is the one functional gap.
+2. **The `pacman -Qi tailscale` guard** in the install hook is likely not
+   needed at all: `add_binary` already fails the build when `tailscaled` is
+   absent, so the guard only buys a friendlier message, and
+   `command -v tailscaled` buys the same one without asking any package
+   manager. Deletion or that one-line swap makes the hook portable.
+3. **The alpm scriptlet** (`mkinitcpio-tailscale.install`, the 2.0.0 TUN
+   migration) is irrelevant to a fresh Void install and needs no counterpart.
+4. **The PKGBUILD and AUR pipeline** are Arch-only by nature and stay that way;
+   see the next section for why no Void package is planned.
+5. **Docs text.** The README's install and next-steps guidance assumes pacman
+   and the AUR, and its systemd rows do not apply on Void.
+
+## The existing Void package
+
+Void's official repos already ship a [`mkinitcpio-tailscale`][void-template]
+(0.1.2), by [@classabbyamp][classabbyamp-repo], whose earlier hook is credited
+in this README as prior work. It is a different, leaner implementation:
+registration via a pre-auth key rather than an interactive setup helper,
+configuration in `/etc/tailscale/tailscaled.conf`, a kernel TUN device with
+iptables in the image rather than userspace networking, and no persisted SSH
+host keys or `--check` equivalent.
+
+The stance here is to coexist, not compete: same problem, same hook name, and a
+maintainer who is also a Void packager. Void users who want what this project
+adds (the setup helper and `--check`, userspace networking with no tun or
+netfilter in the image, persisted Tailscale SSH host identity) can install it
+from git; users who want an `xbps-install` one-liner already have one. A
+void-packages submission under a colliding name is not on the table.
+
+## Manual install sketch
+
+What a Void user would do today, once the gap-list items land. File
+destinations mirror the PKGBUILD's:
+
+```sh
+xbps-install mkinitcpio mkinitcpio-encrypt mkinitcpio-nfs-utils tailscale
+xbps-alternatives -s mkinitcpio
+
+install -m644 -D initcpio-hooks-tailscale   /etc/initcpio/hooks/tailscale
+install -m644 -D initcpio-install-tailscale /etc/initcpio/install/tailscale
+install -m755 -D setup-initcpio-tailscale   /usr/local/bin/setup-initcpio-tailscale
+```
+
+`/etc/initcpio/` is mkinitcpio's user-hook search path, so nothing needs to
+reach into `/usr/lib/initcpio/`, which belongs to xbps. From there the README's
+configure steps apply as written, busybox rows only: register the node, add a
+network hook (`net` or `netconf`, both official packages), place `tailscale`
+before `encrypt` in `HOOKS=`, rebuild with `mkinitcpio -P`, and verify with
+`setup-initcpio-tailscale --check`. The one Void-specific habit is rebuilding
+by hand after a `tailscale` upgrade, since no hook does it for you.
+
+## Validation plan
+
+When the port happens, in this order:
+
+1. **A Void container lane** beside the Arch one in `tests/container.sh`:
+   run the lint, packaging and image-contents scripts (tests/01 to 03) in
+   `ghcr.io/void-linux/void-glibc`, installing `mkinitcpio` and `tailscale`
+   via xbps and copying the hook files into place by hand, since there is no
+   package to install. Building the image with Void's mkinitcpio 41 and
+   inspecting it for `tailscaled`, the passwd database and the tun-module
+   logic covers most of what the port could break.
+2. **A Void QEMU boot scenario** against the throwaway headscale, later. The
+   boot matrix stays Arch-only until the container lane exists and is green.
+
+[void-mkinitcpio]: https://github.com/void-linux/void-packages/blob/master/srcpkgs/mkinitcpio/template
+[void-kernel]: https://docs.voidlinux.org/config/kernel.html
+[void-musl]: https://github.com/void-linux/void-packages/blob/master/srcpkgs/musl/template
+[void-template]: https://github.com/void-linux/void-packages/blob/master/srcpkgs/mkinitcpio-tailscale/template
+[classabbyamp-repo]: https://github.com/classabbyamp/mkinitcpio-tailscale

--- a/docs/void-port.md
+++ b/docs/void-port.md
@@ -84,18 +84,80 @@ The pieces with no Void counterpart, in decreasing order of substance:
 
 Void's official repos already ship a [`mkinitcpio-tailscale`][void-template]
 (0.1.2), by [@classabbyamp][classabbyamp-repo], whose earlier hook is credited
-in this README as prior work. It is a different, leaner implementation:
-registration via a pre-auth key rather than an interactive setup helper,
-configuration in `/etc/tailscale/tailscaled.conf`, a kernel TUN device with
-iptables in the image rather than userspace networking, and no persisted SSH
-host keys or `--check` equivalent.
+in this README as prior work. The two projects solve the same problem with
+different designs, and which one fits is worth deciding deliberately, so the
+differences are spelled out here. Everything below is read against v0.1.2,
+the version Void packages.
+
+### How the two hooks differ
+
+**Registration.** Their `mkinitcpio-tailscale-setup` runs as root with a
+pre-auth key generated in the admin console (`-k <keyfile>`), and asks you to
+stop the system tailscaled first, since it runs the registration daemon on
+the default socket. `setup-initcpio-tailscale` instead starts a throwaway
+tailscaled on its own socket and state, so the system service keeps running;
+it logs in interactively with a URL and QR code (a pre-auth key works too,
+via `--authkey=file:...`), and escalates through sudo or doas exactly once,
+only for the final writes. The nodes register as `<hostname>-mkinitcpio`
+there and `<hostname>-initrd` here.
+
+**Network stack, and what it costs the image.** Their hook always uses a
+kernel TUN device with tailscaled's default netfilter mode, so the image
+carries the tun module, `iptables` and `ip6tables`, all of `/usr/lib/xtables`
+and every netfilter kernel module, plus the `tailscale` CLI, which their boot
+sequence runs. This hook registers the node with `--netfilter-mode=off` and
+runs tailscaled on its userspace network stack, so none of that enters the
+image, not even the tun module, and the CLI stays out unless `CLI="yes"` opts
+it in for debugging (the README measures the CLI alone at about a quarter of
+a systemd image). A kernel TUN device remains available as the `--tun`
+opt-in.
+
+**Boot behavior.** Their runtime hook waits for `/dev/net/tun`, starts
+tailscaled, and then runs `tailscale up --timeout=20s` in the foreground, so
+the boot pauses until the tailnet is up or the timeout passes. This hook
+starts the daemon in the background and lets the boot continue; the state
+file is already logged in, so the node comes up on its own. On teardown their
+cleanup hook is `killall tailscaled`; this one kills the daemon, waits for
+its own teardown, and only then runs `tailscaled --cleanup`, an ordering that
+keeps kernel-TUN routes from leaking past `switch_root`, and it restarts
+tailscaled on the way into the emergency shell, the one moment the node is
+needed most.
+
+**SSH.** Both can serve Tailscale SSH or sit alongside a dropbear. Their hook
+leaves that to the flags you pass and the hooks you add. This one turns
+Tailscale SSH on by default, generates OpenSSH host keys at setup and copies
+them into every image so the node presents the same identity across reboots,
+and writes the minimal user database a busybox image otherwise lacks, without
+which an SSH login cannot be resolved to a user.
+
+**Guard rails.** Their build hook, when setup has not run, prints a message
+and lets the image build without tailscale in it. This one fails the build
+and says what to run, on the view that an image that silently cannot be
+reached defeats the point of the hook. Beyond that there is
+`setup-initcpio-tailscale --check`, which has no counterpart there: hook
+placement in `HOOKS=`, image contents, image staleness against the installed
+daemon, and node key expiry, the failure mode that otherwise surfaces while
+locked out of a machine waiting for its passphrase.
+
+**Scope.** Their hook is busybox-only, which on Void is the only kind of
+image there is; this one also builds systemd images, which matters on Arch
+but is moot on Void. Their configuration lives in
+`/etc/tailscale/tailscaled.conf`, this one's in
+`/etc/initcpio/tailscale/default.env`. Theirs is one `xbps-install` away;
+this one is a manual or xbps-src-template install on Void.
+
+None of this is a knock on 0.1.2: it is a fifth the code, simpler to audit,
+and its pre-auth key flow is easily scripted. The trade is between a small
+hook you configure and verify yourself and a larger one that carries the
+setup, defaults and diagnostics with it. Pick accordingly.
+
+### Coexisting
 
 The stance here is to coexist, not compete: same problem, same hook name, and a
 maintainer who is also a Void packager. Void users who want what this project
-adds (the setup helper and `--check`, userspace networking with no tun or
-netfilter in the image, persisted Tailscale SSH host identity) can install it
-from git; users who want an `xbps-install` one-liner already have one. A
-void-packages submission under a colliding name is not on the table.
+adds can install it from git; users who want an `xbps-install` one-liner
+already have one. A void-packages submission under a colliding name is not on
+the table.
 
 For building a proper XBPS package locally all the same, the repo carries an
 xbps-src template at [contrib/void/template](../contrib/void/template) under
@@ -141,4 +203,4 @@ by hand after a `tailscale` upgrade, since no hook does it for you.
 [void-kernel]: https://docs.voidlinux.org/config/kernel.html
 [void-musl]: https://github.com/void-linux/void-packages/blob/master/srcpkgs/musl/template
 [void-template]: https://github.com/void-linux/void-packages/blob/master/srcpkgs/mkinitcpio-tailscale/template
-[classabbyamp-repo]: https://github.com/classabbyamp/mkinitcpio-tailscale
+[classabbyamp-repo]: https://codeberg.org/classabbyamp/mkinitcpio-tailscale

--- a/initcpio-install-tailscale
+++ b/initcpio-install-tailscale
@@ -6,8 +6,8 @@ build() {
 	# Bumping _builderrors is how a hook actually aborts the build; mkinitcpio
 	# declares and consumes it, and its own acpi_override hook does the same.
 	# shellcheck disable=SC2034
-	if ! pacman -Qi tailscale >/dev/null 2>&1; then
-		error "Package tailscale not installed"
+	if ! command -v tailscaled >/dev/null 2>&1; then
+		error "tailscaled not found; install the tailscale package"
 		builderrors=$((++_builderrors))
 		return 1
 	fi
@@ -141,9 +141,10 @@ help() {
 		actually carry tailscaled, and that the node's key is not about to
 		expire -- without changing anything.
 
-		Once set up, upgrades of the tailscale package rebuild the initramfs on
-		their own through a pacman hook, so the image never keeps booting an old
-		tailscaled.
+		Once set up, on Arch Linux upgrades of the tailscale package rebuild the
+		initramfs on their own through a pacman hook, so the image never keeps
+		booting an old tailscaled. On other distributions run 'mkinitcpio -P'
+		after a tailscale upgrade yourself.
 
 		For more check https://github.com/dangra/mkinitcpio-tailscale
 	__EOF_HELP__

--- a/tests/01-lint.sh
+++ b/tests/01-lint.sh
@@ -25,9 +25,10 @@ command -v shellcheck >/dev/null 2>&1 ||
 # directive in each test script lets shellcheck see lib.sh and fixtures.sh.
 sc_out=$(shellcheck -x "${SCRIPTS[@]}" "${TEST_SCRIPTS[@]}" 2>&1) && sc_rc=0 || sc_rc=$?
 
-# SC2034/SC2154 are structural in a PKGBUILD: makepkg assigns and consumes
-# these, so shellcheck cannot see either end of them.
-pkg_out=$(shellcheck --shell=bash --exclude=SC2034,SC2154 PKGBUILD 2>&1) && pkg_rc=0 || pkg_rc=$?
+# SC2034/SC2154 are structural in a PKGBUILD and an xbps-src template alike:
+# makepkg and xbps-src assign and consume these, so shellcheck cannot see
+# either end of them.
+pkg_out=$(shellcheck --shell=bash --exclude=SC2034,SC2154 PKGBUILD contrib/void/template 2>&1) && pkg_rc=0 || pkg_rc=$?
 
 if ((sc_rc == 0 && pkg_rc == 0)); then
 	pass 'shellcheck reports no findings'
@@ -45,7 +46,7 @@ fi
 endgroup
 
 group 'bash syntax'
-for f in "${SCRIPTS[@]}" PKGBUILD "${TEST_SCRIPTS[@]}"; do
+for f in "${SCRIPTS[@]}" PKGBUILD contrib/void/template "${TEST_SCRIPTS[@]}"; do
 	check "$f parses as bash" bash -n "$f"
 done
 endgroup

--- a/tests/03-initramfs.sh
+++ b/tests/03-initramfs.sh
@@ -16,41 +16,34 @@ USE_INSTALLED=0
 need_root
 need_cmd mkinitcpio lsinitcpio depmod ssh-keygen
 
-# The install hook bails out unless the tailscale package is present.
-need_pkg tailscale
+# The install hook bails out unless tailscaled is on PATH.
+need_cmd tailscaled
 
 WORK=$(mktemp -d)
 BUILD_N=0
 
-# Simulating "tailscale is not installed" cannot be done with a PATH shim:
+# Simulating "tailscaled is not installed" cannot be done with a PATH shim:
 # mkinitcpio hard-resets PATH to /usr/bin:/bin at startup (mkinitcpio:39), so
-# the hook's `pacman -Qi tailscale` always finds the real binary. Swapping
-# /usr/bin/pacman itself is the only thing that works, which is safe here
-# because fixtures_init already refuses to run outside a container.
-PACMAN_SHIMMED=0
+# the hook's `command -v tailscaled` always finds the real binary. Moving
+# /usr/bin/tailscaled itself aside is the only thing that works, which is safe
+# here because fixtures_init already refuses to run outside a container.
+TAILSCALED_SHIMMED=0
 
-shim_pacman() {
-	mv /usr/bin/pacman /usr/bin/pacman.real || die 'could not move pacman aside'
-	cat >/usr/bin/pacman <<-'EOF'
-		#!/usr/bin/env bash
-		[[ $1 == -Qi && $2 == tailscale ]] && exit 1
-		exec /usr/bin/pacman.real "$@"
-	EOF
-	chmod 755 /usr/bin/pacman
-	PACMAN_SHIMMED=1
+shim_tailscaled() {
+	mv /usr/bin/tailscaled /usr/bin/tailscaled.hidden || die 'could not move tailscaled aside'
+	TAILSCALED_SHIMMED=1
 }
 
-unshim_pacman() {
-	((PACMAN_SHIMMED)) || return 0
-	rm -f /usr/bin/pacman
-	mv /usr/bin/pacman.real /usr/bin/pacman
-	PACMAN_SHIMMED=0
+unshim_tailscaled() {
+	((TAILSCALED_SHIMMED)) || return 0
+	mv /usr/bin/tailscaled.hidden /usr/bin/tailscaled
+	TAILSCALED_SHIMMED=0
 }
 
 # fixtures_init installs its own EXIT trap; chain ours so both run.
 cleanup_all() {
 	local rc=$?
-	unshim_pacman
+	unshim_tailscaled
 	rm -rf "$WORK"
 	fixtures_cleanup
 	return $rc
@@ -62,14 +55,26 @@ trap cleanup_all EXIT
 # --- kernel ---------------------------------------------------------------
 # The container's `uname -r` is the runner's kernel, for which no module tree
 # exists, so take the version from whichever tree a kernel package installed.
+# pkgbase marks Arch's kernel packages; Void's install a plain module tree,
+# which the kernel/ directory identifies.
 KVER=''
 for d in /usr/lib/modules/*/; do
-	[[ -f ${d}pkgbase ]] && KVER=$(basename "$d")
+	[[ -f ${d}pkgbase || -d ${d}kernel ]] && KVER=$(basename "$d")
 done
 [[ -n $KVER ]] || die 'no kernel module tree found; install the linux package'
 [[ -f /usr/lib/modules/$KVER/modules.dep ]] || depmod -a "$KVER" ||
 	die "depmod failed for $KVER"
 info "building against kernel $KVER"
+
+# A busybox-only distro (Void) can only build busybox images: mkinitcpio's
+# systemd install hook copies the host's systemd into the image, and there is
+# none. The systemd-specific variants are skipped there; everything that only
+# needs some working image builds against whichever init this host has.
+HAVE_SYSTEMD=0
+[[ -x /usr/lib/systemd/systemd && -f /usr/lib/initcpio/install/systemd ]] && HAVE_SYSTEMD=1
+ANY_INIT_HOOKS='base systemd tailscale'
+((HAVE_SYSTEMD)) || ANY_INIT_HOOKS='base udev tailscale'
+((HAVE_SYSTEMD)) || info 'no systemd on this host; skipping the systemd variants'
 
 # --- where mkinitcpio looks for the hook ----------------------------------
 MKI_HOOKDIR_ARGS=()
@@ -186,6 +191,7 @@ assert_common() {
 }
 
 # --- variant A: systemd ---------------------------------------------------
+if ((HAVE_SYSTEMD)); then
 group 'variant A: systemd initramfs'
 fixtures_write
 if build_image 'base systemd tailscale'; then
@@ -217,6 +223,7 @@ else
 	fail 'A: mkinitcpio builds' "$(tail -30 "$LOG")"
 fi
 endgroup
+fi
 
 # --- variant B: busybox ---------------------------------------------------
 group 'variant B: busybox initramfs'
@@ -258,6 +265,7 @@ fi
 endgroup
 
 # --- variant C: systemd with Tailscale SSH host keys ----------------------
+if ((HAVE_SYSTEMD)); then
 group 'variant C: systemd initramfs with ssh host keys'
 fixtures_write --ssh
 if build_image 'base systemd tailscale'; then
@@ -280,6 +288,7 @@ else
 	fail 'C: mkinitcpio builds' "$(tail -30 "$LOG")"
 fi
 endgroup
+fi
 
 # --- variant D: busybox with Tailscale SSH host keys ----------------------
 # The host keys are copied by the part of build() that runs before the init
@@ -330,14 +339,16 @@ group 'variant D2: kernel TUN opt-in'
 fixtures_write
 printf 'TUN="tailscale0"\n' >>"$FIXTURE_SRC/default.env"
 printf 'TUN="tailscale0"\n' >>"$TS_SETUPDIR/default.env"
-if build_image 'base systemd tailscale'; then
-	pass 'D2: systemd build with TUN=tailscale0'
-	snapshot
-	assert_common D2 tun
-	img_grep "$ROOT" etc/systemd/system/tailscaled.service.d/override.conf \
-		'^ExecStart=.* --tun=tailscale0 '
-else
-	fail 'D2: systemd build with TUN=tailscale0' "$(tail -30 "$LOG")"
+if ((HAVE_SYSTEMD)); then
+	if build_image 'base systemd tailscale'; then
+		pass 'D2: systemd build with TUN=tailscale0'
+		snapshot
+		assert_common D2 tun
+		img_grep "$ROOT" etc/systemd/system/tailscaled.service.d/override.conf \
+			'^ExecStart=.* --tun=tailscale0 '
+	else
+		fail 'D2: systemd build with TUN=tailscale0' "$(tail -30 "$LOG")"
+	fi
 fi
 if build_image 'base udev tailscale'; then
 	pass 'D2: busybox build with TUN=tailscale0'
@@ -353,12 +364,12 @@ group 'variant D3: CLI="yes" puts the tailscale CLI back'
 fixtures_write
 printf 'CLI="yes"\n' >>"$FIXTURE_SRC/default.env"
 printf 'CLI="yes"\n' >>"$TS_SETUPDIR/default.env"
-if build_image 'base systemd tailscale'; then
-	pass 'D3: systemd build with CLI=yes'
+if build_image "$ANY_INIT_HOOKS"; then
+	pass 'D3: build with CLI=yes'
 	snapshot
 	assert_common D3 cli
 else
-	fail 'D3: systemd build with CLI=yes' "$(tail -30 "$LOG")"
+	fail 'D3: build with CLI=yes' "$(tail -30 "$LOG")"
 fi
 endgroup
 
@@ -375,7 +386,7 @@ group 'variants E-G: guard clauses reject bad configuration'
 # assert_guard <label> <error regex> — the build must be refused outright
 assert_guard() {
 	local label=$1 re=$2 rc=0
-	build_image 'base systemd tailscale' || rc=$?
+	build_image "$ANY_INIT_HOOKS" || rc=$?
 
 	check "$label: the hook reports the problem" grep -qE "$re" "$LOG"
 
@@ -406,9 +417,9 @@ rm -f "$TS_SETUPDIR/default.env"
 assert_guard 'F: missing default.env' 'default\.env'
 
 fixtures_write
-shim_pacman
-assert_guard 'G: tailscale package absent' 'tailscale not installed'
-unshim_pacman
+shim_tailscaled
+assert_guard 'G: tailscaled absent' 'tailscaled not found'
+unshim_tailscaled
 endgroup
 
 # --- the libalpm hook script -----------------------------------------------
@@ -538,6 +549,9 @@ endgroup
 # post_upgrade pins TUN="tailscale0" into an existing default.env exactly when
 # the old version predates 2.0.0 and the user has not chosen a TUN themselves,
 # preserving the kernel-TUN behaviour such machines were set up with.
+# The scriptlet is alpm's to run and compares versions with vercmp, which only
+# pacman ships; on other distros there is nothing to test.
+if command -v vercmp >/dev/null 2>&1; then
 group 'variant K: install scriptlet pins TUN across the 2.0.0 boundary'
 
 # shellcheck source=/dev/null
@@ -588,6 +602,9 @@ rm -rf "$TS_SETUPDIR"
 post_upgrade 2.1.0 1.5.0 >/dev/null || true
 check_fails 'K: nothing is created where setup never ran' test -e "$TS_SETUPDIR/default.env"
 endgroup
+else
+	info 'no vercmp on this host; skipping the install scriptlet variant'
+fi
 
 # --- variant L: --check notices a stale image -------------------------------
 # The pacman hook rebuilds when tailscale is upgraded, so an image older than
@@ -596,7 +613,7 @@ endgroup
 group 'variant L: --check reports an image older than tailscaled'
 
 fixtures_write
-if build_image 'base systemd tailscale' >/dev/null 2>&1; then
+if build_image "$ANY_INIT_HOOKS" >/dev/null 2>&1; then
 	snapshot
 	printf 'HOOKS=(base systemd sd-network tailscale sd-encrypt filesystems)\n' \
 		>/etc/mkinitcpio.conf

--- a/tests/container.sh
+++ b/tests/container.sh
@@ -1,19 +1,36 @@
 #!/usr/bin/env bash
-# Runs the test suite in a throwaway Arch container, so it never touches the
+# Runs the test suite in a throwaway container, so it never touches the
 # host's /etc/initcpio/tailscale or installed packages.
 #
-#   tests/container.sh              # 01-lint, 02-package, 03-initramfs
+#   tests/container.sh              # 01-lint, 02-package, 03-initramfs, on Arch
 #   tests/container.sh all          # plus the QEMU boot test
 #   tests/container.sh 01 02        # a subset
+#   tests/container.sh void         # 01-lint, 03-initramfs, on Void Linux
+#   tests/container.sh void 03      # a subset of that
+#
+# The void lane builds and inspects images with Void's mkinitcpio on a host
+# with no systemd, which is what a Void machine running this hook looks like;
+# see docs/void-port.md. It has no 02 or 04: those stages build an Arch
+# package and boot an Arch userland.
 #
 # Uses podman if available, otherwise docker. CI's lint, package and initramfs
-# jobs run tests/NN-*.sh directly in an Arch `container:` job, so the package set
-# below is kept in step with the workflow. The boot job does call this script,
+# jobs run tests/NN-*.sh directly in `container:` jobs, so the package sets
+# below are kept in step with the workflow. The boot job does call this script,
 # so that --device /dev/kvm is only passed when the runner actually has KVM.
 set -euo pipefail
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO=$(cd -- "$HERE/.." && pwd)
-IMAGE=${IMAGE:-docker.io/library/archlinux:base-devel}
+
+DISTRO=arch
+if [[ ${1:-} == void ]]; then
+	DISTRO=void
+	shift
+fi
+if [[ $DISTRO == void ]]; then
+	IMAGE=${IMAGE:-ghcr.io/void-linux/void-glibc:latest}
+else
+	IMAGE=${IMAGE:-docker.io/library/archlinux:base-devel}
+fi
 
 ENGINE=${ENGINE:-}
 if [[ -z $ENGINE ]]; then
@@ -22,23 +39,45 @@ if [[ -z $ENGINE ]]; then
 fi
 
 STAGES=("$@")
-((${#STAGES[@]})) || STAGES=(01 02 03)
+if [[ $DISTRO == void ]]; then
+	((${#STAGES[@]})) || STAGES=(01 03)
+	for s in "${STAGES[@]}"; do
+		[[ $s == 01* || $s == 03* ]] ||
+			{ echo "the void lane runs stages 01 and 03 only, not '$s'" >&2; exit 2; }
+	done
+else
+	((${#STAGES[@]})) || STAGES=(01 02 03)
+fi
 WANTS_ALL=0
 [[ ${STAGES[0]} == all ]] && WANTS_ALL=1
 
 # Only install what the requested stages need; pulling the kernel and QEMU for
 # a lint run would be a waste.
-PKGS=(git)
 want() {
 	((WANTS_ALL)) && return 0
 	local s
 	for s in "${STAGES[@]}"; do [[ $s == "$1"* ]] && return 0; done
 	return 1
 }
-want 01 && PKGS+=(shellcheck mkinitcpio)
-want 02 && PKGS+=(pacman-contrib namcap)
-want 03 && PKGS+=(mkinitcpio linux tailscale openssh)
-want 04 && PKGS+=(mkinitcpio linux tailscale openssh qemu-base jq curl dropbear opendoas)
+if [[ $DISTRO == void ]]; then
+	# bash is named because the base container only guarantees sh, and the
+	# whole suite runs under bash. The rest fills the distance between the
+	# slim container and a real Void system: mkinitcpio builds images with
+	# find, the keymap and consolefont hooks run loadkeys and setfont (kbd,
+	# part of base-system), and the tests byte-compare with cmp and diff.
+	# The kernel is kept out of PKGS: it goes in on its own after mkinitcpio's
+	# kernel hook has been disarmed below.
+	PKGS=(bash)
+	KERNEL_PKGS=()
+	want 01 && PKGS+=(shellcheck mkinitcpio)
+	want 03 && { PKGS+=(findutils diffutils kbd mkinitcpio tailscale openssh); KERNEL_PKGS=(linux); }
+else
+	PKGS=(git)
+	want 01 && PKGS+=(shellcheck mkinitcpio)
+	want 02 && PKGS+=(pacman-contrib namcap)
+	want 03 && PKGS+=(mkinitcpio linux tailscale openssh)
+	want 04 && PKGS+=(mkinitcpio linux tailscale openssh qemu-base jq curl dropbear opendoas)
+fi
 
 RUN_OPTS=()
 [[ -t 0 && -t 1 ]] && RUN_OPTS+=(-it)
@@ -61,8 +100,49 @@ if ((WANTS_ALL)) || want 04; then
 	[[ -e /dev/kvm ]] && RUN_OPTS+=(--device /dev/kvm)
 fi
 
-# PKGS and STAGES are passed in as environment variables and expanded by the
-# shell inside the container, so the script below is deliberately single-quoted.
+# The package and stage lists are passed in as environment variables and
+# expanded by the shell inside the container, so the scripts below are
+# deliberately single-quoted.
+
+if [[ $DISTRO == void ]]; then
+	# sh rather than bash on the outside: the base container has no bash until
+	# the install below brings it in.
+	# shellcheck disable=SC2016
+	exec "$ENGINE" run --rm "${RUN_OPTS[@]}" \
+		-v "$REPO:/src:ro" -w /src \
+		-e "STAGES=${STAGES[*]}" \
+		-e "PKGS=${PKGS[*]}" \
+		-e "KERNEL_PKGS=${KERNEL_PKGS[*]}" \
+		"$IMAGE" \
+		sh -euc '
+			# The container image slims itself with noextract rules that also
+			# strip files mkinitcpio needs at image build time, the udev
+			# helpers among them. Drop the rules before anything installs, and
+			# reinstall the two packages whose payloads the image was built
+			# without, so the container looks like a real Void system where it
+			# matters.
+			rm -f /etc/xbps.d/noextract*.conf
+
+			xbps-install -Syu xbps >/dev/null
+			xbps-install -yu >/dev/null
+			xbps-install -y $PKGS >/dev/null
+			xbps-install -yf eudev libkmod >/dev/null
+
+			# Installing a kernel runs the /etc/kernel.d hooks, and with
+			# mkinitcpio now installed its hook would build an initramfs
+			# against the stock preset, which cannot work in a container
+			# (autodetect needs the real host). A /dev/null symlink is not
+			# executable, so the kernel trigger skips it; the tests build
+			# their images with their own configuration.
+			if [ -n "$KERNEL_PKGS" ]; then
+				ln -sf /dev/null /etc/kernel.d/post-install/20-initramfs
+				xbps-install -y $KERNEL_PKGS >/dev/null
+			fi
+
+			exec /src/tests/run.sh $STAGES
+		'
+fi
+
 # shellcheck disable=SC2016
 exec "$ENGINE" run --rm "${RUN_OPTS[@]}" \
 	-v "$REPO:/src:ro" -w /src \


### PR DESCRIPTION
Started as a research report on reusing this hook on Void Linux; now also implements what the report found, so the branch delivers working Void support end to end. Five commits:

1. **`docs/void-port.md`** — the research: Void supports mkinitcpio as a first-class dracut alternative (version 41, plus packaged `net`, `netconf`, `dropbear` and `encrypt` hooks), most of this codebase was already distro-neutral, and the systemd branch disables itself by feature detection on a distro with no systemd.
2. **Portability** — the `pacman -Qi tailscale` guard becomes `command -v tailscaled` (`add_binary` fails without it anyway; the guard only buys the friendlier message), kernel detection in tests/03 accepts Void's plain module trees next to Arch's `pkgbase`-marked ones, and the systemd-specific test variants skip themselves on a busybox-only host.
3. **Void test lane** — `make test-void` / `tests/container.sh void` runs the lint and image-contents stages in `ghcr.io/void-linux/void-glibc`, and CI gains a matching `initramfs (void)` job. The bootstrap undoes the container image's `noextract` slimming (which strips the udev helpers, `find`, `cmp`, `loadkeys`) so the container looks like a real Void system where mkinitcpio cares.
4. **Docs** — the report is updated to the implemented state, and the README gains a short Void Linux section pointing at it.
5. **xbps-src template** — `contrib/void/template` packages the project for local `xbps-src` builds under the proposed name **`initcpio-tailscale`** (the name this repo's own files already carry), with `conflicts` on the official `mkinitcpio-tailscale` since both install the `tailscale` hook. Deliberately not submitted to void-packages, per the coexist stance; lint holds it to the PKGBUILD standard.

What stays Arch-only, by design: the libalpm rebuild-on-tailscale-upgrade pair (XBPS has no transaction hooks; on Void that is a documented manual rebuild), the alpm scriptlet, and the PKGBUILD/AUR pipeline.

Verified: `make test` passes on Arch (189 checks) and `make test-void` passes on Void (121 checks, images built with Void's mkinitcpio 41, no systemd); the lint stage covering the template passes in both containers. Research claims were checked on 2026-08-18 against the Void handbook, void-packages templates, a live mirror, and mkinitcpio's source.