### PR TITLE
Point the Void template at v2.6.0

### DIFF
--- a/contrib/void/template
+++ b/contrib/void/template
@@ -18,7 +18,7 @@
 # unlike the Arch package nothing rebuilds the initramfs when tailscale is
 # upgraded: run mkinitcpio -P yourself afterwards.
 pkgname=initcpio-tailscale
-version=2.5.0
+version=2.6.0
 revision=1
 depends="mkinitcpio tailscale"
 short_desc="Tailscale in the initramfs, with setup helper and Tailscale SSH"
@@ -26,7 +26,7 @@ maintainer="Daniel Graña <dangra@gmail.com>"
 license="GPL-2.0-or-later"
 homepage="https://github.com/dangra/mkinitcpio-tailscale"
 distfiles="https://github.com/dangra/mkinitcpio-tailscale/archive/refs/tags/v${version}.tar.gz"
-checksum=96b9fc3aa5504fab5aa7365f06d30fee2783278456ffefeb8e1387c12800cffe
+checksum=a0cd9b1e8873e2f6303f06c717aa1e13d41c4ecc6795cd913d4a96bbb30ccdc4
 # Both packages install /usr/lib/initcpio/{install,hooks}/tailscale: the hook
 # is named 'tailscale' in HOOKS= either way, so only one can be present.
 conflicts="mkinitcpio-tailscale>=0"


### PR DESCRIPTION
The template pinned v2.5.0, whose install hook still asks pacman whether the tailscale package is installed; on Void that guard fails and the build is refused, so a package built from that tarball could never work where it is meant to be used. v2.6.0 is the first release carrying the portable guard. Bumps version and the tarball checksum (verified against the tag's archive).