### PR TITLE
Let tailscaled generate the SSH host keys, dropping openssh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
           # mkinitcpio is named explicitly because linux depends on the virtual
           # "initramfs" provider and --noconfirm could otherwise pick dracut.
           pacman -Syu --noconfirm --needed \
-            git mkinitcpio linux tailscale openssh
+            git mkinitcpio linux tailscale
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -22,8 +22,7 @@ license=("GPL-2.0-or-later")
 # tailscale is needed at image build time: the install hook copies tailscaled
 # into the image, and add_binary fails the build without it.
 depends=("mkinitcpio" "tailscale")
-optdepends=("openssh: host key generation for the default Tailscale SSH setup"
-  "jq: node key expiry checking in setup-initcpio-tailscale --check")
+optdepends=("jq: node key expiry checking in setup-initcpio-tailscale --check")
 install=mkinitcpio-tailscale.install
 source=("initcpio-hooks-tailscale"
   "initcpio-install-tailscale"

--- a/README.md
+++ b/README.md
@@ -199,9 +199,10 @@ accept local connections unless the client is also part of your Tailscale
 network, which reduces exposure compared to a traditional SSH server reachable
 from everywhere.
 
-The setup helper also generates OpenSSH host keys and stores them alongside
-the node key, so the initramfs presents the same host key every time and your
-client does not warn about a changed identity.
+The isolated tailscaled the setup helper runs also generates the SSH host keys
+its server will use, and they are stored alongside the node key, so the
+initramfs presents the same host key every time and your client does not warn
+about a changed identity.
 
 Works on systemd- and busybox-based initramfs alike, though the second needs a
 hand: Tailscale's SSH server has to resolve the user you log in as, and of the

--- a/setup-initcpio-tailscale
+++ b/setup-initcpio-tailscale
@@ -20,8 +20,8 @@ Defaults:
   --hostname    the current hostname plus an '-initrd' suffix, in this case "${TS_HOSTNAME}".
 
   --ssh         Tailscale's built-in SSH server is enabled, so the initramfs is
-                reachable without a second ssh server in it. OpenSSH host keys
-                are generated alongside the node key so the image presents the
+                reachable without a second ssh server in it. SSH host keys are
+                generated alongside the node key so the image presents the
                 same identity on every boot.
 
   --no-ssh      Turns that off, for images that run their own dropbear or
@@ -133,8 +133,11 @@ EOF
   fi
 
   if [[ $ssh == yes ]]; then
-    install -o root -g root -m600 -Dt "${TS_STATEDIR}/ssh" "${setupdir}/etc/ssh/"ssh_host_*_key
-    install -o root -g root -m644 -Dt "${TS_STATEDIR}/ssh" "${setupdir}/etc/ssh/"ssh_host_*_key.pub
+    # Replaced wholesale: an earlier run may have left keys of other types or
+    # formats behind (the openssh era also wrote .pub files), and anything
+    # still here would be copied into every image built from now on.
+    rm -rf "${TS_STATEDIR}/ssh"
+    install -o root -g root -m600 -Dt "${TS_STATEDIR}/ssh" "${setupdir}/ssh/"ssh_host_*_key
   else
     # Host keys left behind by an earlier run would otherwise be copied into
     # every image built from here on, for a server this node no longer runs.
@@ -513,21 +516,29 @@ SETUPDIR="$(mktemp -d)"
 socket="${SETUPDIR}/tailscaled.sock"
 state="${SETUPDIR}/tailscaled.state"
 
-if [[ $TS_SSH == yes ]]; then
-  # Checked before anything registers, so a missing openssh fails cleanly
-  # instead of via set -e halfway through, and names the way out.
-  command -v ssh-keygen >/dev/null ||
-    die "ssh-keygen not found: install openssh, or pass --no-ssh to skip Tailscale SSH"
-  # ssh-keygen -A writes into <prefix>/etc/ssh and will not create the directory
-  # itself. The keys are the initrd node's stable identity: generating them here,
-  # rather than letting the image make new ones on each boot, is what keeps a
-  # client from warning about a changed host key every time the machine reboots.
-  mkdir -p "${SETUPDIR}/etc/ssh"
-  ssh-keygen -A -f "${SETUPDIR}"
+# The SSH host keys come from tailscaled itself: with -statedir set it writes
+# ssh_host_{rsa,ecdsa,ed25519}_key under ${SETUPDIR}/ssh the moment 'up' applies
+# an SSH-enabled preference, which is also when it advertises the public halves
+# to the control plane. Generating them here, rather than letting the image make
+# new ones on each boot, is what keeps a client from warning about a changed
+# host key every time the machine reboots.
+#
+# The daemon must not run as root for that: a root tailscaled prefers this
+# host's own /etc/ssh keys over generating dedicated ones, and the machine's
+# real identity would end up advertised for the image while the image itself,
+# lacking those files, mints fresh keys on every boot. Userspace networking
+# needs no privileges anyway, so a root invocation drops this one process to
+# nobody; the redirections are opened first, by root, and the state install
+# below re-owns everything to root.
+asuser=()
+if [[ "$(id -u)" == 0 ]]; then
+  chown nobody "$SETUPDIR"
+  asuser=(setpriv --reuid=nobody --regid=nobody --clear-groups --)
 fi
 
-tailscaled \
+"${asuser[@]}" tailscaled \
   -state="$state" \
+  -statedir="$SETUPDIR" \
   -socket="$socket" \
   -no-logs-no-support \
   -tun=userspace-networking \
@@ -539,6 +550,19 @@ PID="$!"
 if ! tailscale --socket="$socket" up --qr --accept-risk=lose-ssh "$@"; then
   cp -f "${SETUPDIR}/setup.log" /tmp/setup-initcpio-tailscale-daemon.log
   die "Failed to configure tailscale. Check daemon logs at /tmp/setup-initcpio-tailscale-daemon.log"
+fi
+
+# The keys the state install below copies, checked before anything is written:
+# 'up' returning means the SSH preference was applied, so by now all three must
+# exist. A gap means tailscaled changed how it generates host keys, and is
+# worth a clean failure rather than an image with a per-boot identity.
+if [[ $TS_SSH == yes ]]; then
+  for typ in rsa ecdsa ed25519; do
+    if [[ ! -s "${SETUPDIR}/ssh/ssh_host_${typ}_key" ]]; then
+      cp -f "${SETUPDIR}/setup.log" /tmp/setup-initcpio-tailscale-daemon.log
+      die "tailscaled did not generate the ${typ} SSH host key. Check daemon logs at /tmp/setup-initcpio-tailscale-daemon.log"
+    fi
+  done
 fi
 
 # The one escalation boundary of the whole flow: as root, install the state

--- a/tests/03-initramfs.sh
+++ b/tests/03-initramfs.sh
@@ -14,7 +14,7 @@ USE_INSTALLED=0
 [[ ${1:-} == --installed ]] && USE_INSTALLED=1
 
 need_root
-need_cmd mkinitcpio lsinitcpio depmod ssh-keygen
+need_cmd mkinitcpio lsinitcpio depmod openssl
 
 # The install hook copies tailscaled into every image it builds.
 need_cmd tailscaled
@@ -259,7 +259,7 @@ if build_image 'base systemd tailscale'; then
 	assert_common C
 
 	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key
-	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key.pub
+	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ecdsa_key
 	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_rsa_key
 	img_same "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key \
 		"$FIXTURE_SRC/ssh/ssh_host_ed25519_key"
@@ -286,7 +286,7 @@ if build_image 'base udev tailscale'; then
 
 	img_has "$ROOT" hooks/tailscale
 	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key
-	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key.pub
+	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_ecdsa_key
 	img_has "$ROOT" var/lib/tailscale/ssh/ssh_host_rsa_key
 	img_same "$ROOT" var/lib/tailscale/ssh/ssh_host_ed25519_key \
 		"$FIXTURE_SRC/ssh/ssh_host_ed25519_key"

--- a/tests/04-boot.sh
+++ b/tests/04-boot.sh
@@ -395,6 +395,11 @@ node_ip() {
 # sessions of the later scenarios expire while the first one boots rather than
 # stalling each boot in turn.
 group 'setup-initcpio-tailscale against headscale'
+# A deliberate trap for the setup helper's privilege drop: give this host a
+# real /etc/ssh identity. A tailscaled running as root prefers these keys over
+# generating its own, so if the helper ever runs its daemon privileged again,
+# the identity assertion below sees the borrowed key instead of a fresh one.
+[[ -s /etc/ssh/ssh_host_ed25519_key ]] || ssh-keygen -q -A
 for sc in "${SCENARIOS[@]}"; do
 	node="${TS_NODE_NAME}-${SC_SUFFIX[$sc]}"
 
@@ -425,8 +430,26 @@ for sc in "${SCENARIOS[@]}"; do
 			test -s "$TS_SETUPDIR/ssh/ssh_host_ed25519_key"
 		check "$sc: the private host key is mode 600" \
 			test "$(stat -c %a "$TS_SETUPDIR/ssh/ssh_host_ed25519_key" 2>/dev/null)" = 600
-		# What the ssh assertions later compare the offered host key against.
-		cp "$TS_SETUPDIR/ssh/ssh_host_ed25519_key.pub" "$WORK/hostkey.$sc.pub"
+		# tailscaled writes PKCS#8 PEM; ssh-keygen would have left an OPENSSH
+		# block instead, so the header doubles as a provenance check.
+		check "$sc: the host key is tailscaled-generated PKCS#8" \
+			grep -q -- '-----BEGIN PRIVATE KEY-----' "$TS_SETUPDIR/ssh/ssh_host_ed25519_key"
+		# The setup dir carries private keys only; the public half, derived
+		# here, is what the ssh assertions later compare the offered host key
+		# against.
+		if ssh-keygen -y -f "$TS_SETUPDIR/ssh/ssh_host_ed25519_key" \
+			>"$WORK/hostkey.$sc.pub" 2>"$WORK/derive.$sc.log" &&
+			[[ -s $WORK/hostkey.$sc.pub ]]; then
+			pass "$sc: the public host key derives from the private key"
+		else
+			fail "$sc: the public host key derives from the private key" \
+				"$(cat "$WORK/derive.$sc.log")"
+		fi
+		# The daemon runs unprivileged exactly so it cannot adopt the /etc/ssh
+		# identity planted above the loop.
+		check "$sc: the host key is not this machine's /etc/ssh identity" \
+			test "$(awk '{print $1, $2}' "$WORK/hostkey.$sc.pub")" != \
+			"$(awk '{print $1, $2}' /etc/ssh/ssh_host_ed25519_key.pub)"
 	fi
 	if [[ ${SC_SETUP_ARGS[$sc]} == *--tun* ]]; then
 		check "$sc: default.env carries TUN=tailscale0" \

--- a/tests/container.sh
+++ b/tests/container.sh
@@ -38,7 +38,7 @@ want() {
 PKGS=(git)
 want 01 && PKGS+=(shellcheck mkinitcpio)
 want 02 && PKGS+=(pacman-contrib namcap)
-want 03 && PKGS+=(mkinitcpio linux tailscale openssh)
+want 03 && PKGS+=(mkinitcpio linux tailscale)
 want 04 && PKGS+=(mkinitcpio linux tailscale openssh qemu-base jq curl dropbear opendoas)
 
 RUN_OPTS=()

--- a/tests/fixtures.sh
+++ b/tests/fixtures.sh
@@ -101,13 +101,17 @@ fixtures_write() {
 	install -m644 -t "$TS_SETUPDIR" "$FIXTURE_SRC/default.env"
 
 	if ((with_ssh)); then
-		# ssh-keygen -A writes into <prefix>/etc/ssh and will not create it.
-		install -dm700 "$FIXTURE_SRC/ssh" "$FIXTURE_SRC/etc/ssh"
-		ssh-keygen -q -A -f "$FIXTURE_SRC" >/dev/null
-		mv "$FIXTURE_SRC"/etc/ssh/ssh_host_* "$FIXTURE_SRC/ssh/"
-		rm -rf "${FIXTURE_SRC:?}/etc"
+		# The same three keys the setup helper's tailscaled generates, in the
+		# same PKCS#8 PEM format (ssh/tailssh/hostkeys.go upstream), private
+		# halves only: tailscaled derives the public keys itself.
+		install -dm700 "$FIXTURE_SRC/ssh"
+		openssl genpkey -quiet -algorithm ed25519 \
+			-out "$FIXTURE_SRC/ssh/ssh_host_ed25519_key"
+		openssl genpkey -quiet -algorithm EC -pkeyopt ec_paramgen_curve:P-256 \
+			-out "$FIXTURE_SRC/ssh/ssh_host_ecdsa_key"
+		openssl genpkey -quiet -algorithm RSA -pkeyopt rsa_keygen_bits:2048 \
+			-out "$FIXTURE_SRC/ssh/ssh_host_rsa_key"
 		install -dm700 "$TS_SETUPDIR/ssh"
 		install -m600 -t "$TS_SETUPDIR/ssh" "$FIXTURE_SRC/ssh/"ssh_host_*_key
-		install -m644 -t "$TS_SETUPDIR/ssh" "$FIXTURE_SRC/ssh/"ssh_host_*_key.pub
 	fi
 }


### PR DESCRIPTION
The setup helper used `ssh-keygen -A` for the image's SSH host keys, which made openssh an optional dependency of the default flow and a hard stop when it was missing. tailscaled generates those keys itself: with `-statedir` set it writes `ssh_host_{rsa,ecdsa,ed25519}_key` under `<statedir>/ssh`, in PKCS#8 PEM, the moment `up` applies an SSH-enabled preference (upstream `ssh/tailssh/hostkeys.go`), and that is the very directory the install hook already copies into the image. The isolated setup daemon now generates the identity it will later serve, and ssh-keygen is gone along with the optdepends entry and the `.pub` files, which tailscaled never needed.

The one trap is privilege: a tailscaled running as root prefers the host's real `/etc/ssh` keys over generating its own, which would advertise the machine's identity for an image that cannot carry it. A root invocation therefore drops the daemon to `nobody` with setpriv; userspace networking needs no privileges, and the state install re-owns everything to root as it always did. A missing key after `up` fails the run cleanly rather than shipping an image that mints a fresh identity on every boot.

The 03 fixtures mint the same PKCS#8 keys with openssl, so that lane no longer installs openssh; the boot lane keeps openssh as its ssh client. New assertions there prove the key is tailscaled-generated PKCS#8, that its public half derives from the private one, and, against `/etc/ssh` keys planted for the purpose, that the image identity is not the host's. All lanes pass in the container: 186 checks for 01-03, and 104 for the five QEMU boot scenarios, each ending in an ssh session against the booted image that sees the setup-time host key.